### PR TITLE
Fix: Add missing executable to the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.14)
 project(redis)
 
+add_executable(redis_lite
+    src/resp.c
+    src/server.c
+)
+
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This was initially supposed to be part of the implement the PING and ECHO commands issue, but for some reason it was not in the branch. This enables the redis_list executable to created when building the project.