### PR TITLE
Implement handling of concurrent clients

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 2
+ColumnLimit: 100
+AllowShortIfStatementsOnASingleLine: true

--- a/src/resp.c
+++ b/src/resp.c
@@ -129,6 +129,16 @@ char *serialize_array(const char **arr, int count) {
 // "*2\r\n$4\r\necho\r\n$11\r\nhello world\r\n”
 // a command is an array of bulk strings
 char **deserialize_command(const char *input, int *count) {
+  if (strncmp(input, "PING", 4) == 0) {
+    *count = 1;
+    char **result = (char **)malloc(sizeof(char *));
+    if (result == NULL) {
+      return NULL;
+    }
+    result[0] = strdup("PING");
+    return result;
+  }
+
   if (input == NULL || input[0] != '*') {
     *count = 0;
     return NULL; // not an array, invalid command

--- a/src/resp.c
+++ b/src/resp.c
@@ -19,7 +19,7 @@ char *serialize_simple_string(const char *str) {
   // terminator
   char *serialized = (char *)malloc(len + 4);
   if (serialized == NULL) {
-    return NULL;  // memory allocation failed
+    return NULL; // memory allocation failed
   }
 
   // format the serialized string
@@ -59,7 +59,7 @@ char *serialize_integer(const int val) {
 
 char *serialize_bulk_string(const char *str) {
   if (str == NULL) {
-    return strdup("$-1\r\n");  // null representation of bulk string
+    return strdup("$-1\r\n"); // null representation of bulk string
   }
 
   size_t str_len = strlen(str);
@@ -90,7 +90,7 @@ char *serialize_array(const char **arr, int count) {
   for (int i = 0; i < count; i++) {
     const char *str = arr[i];
     if (str == NULL) {
-      total_len += 5;  // for "$-1\r\n"
+      total_len += 5; // for "$-1\r\n"
     } else {
       size_t str_len = strlen(str);
       // 1 for "$", length of str_len, 2 for "\r\n", str_len, 2 for last "\r\n"
@@ -99,7 +99,7 @@ char *serialize_array(const char **arr, int count) {
   }
 
   // allocate memory for the serialized array
-  char *serialized = (char *)malloc(total_len + 1);  // + 1 for null terminator
+  char *serialized = (char *)malloc(total_len + 1); // + 1 for null terminator
   if (serialized == NULL) {
     return NULL;
   }
@@ -122,7 +122,7 @@ char *serialize_array(const char **arr, int count) {
     }
   }
 
-  *current = '\0';  // null terminate the string
+  *current = '\0'; // null terminate the string
   return serialized;
 }
 
@@ -131,7 +131,7 @@ char *serialize_array(const char **arr, int count) {
 char **deserialize_command(const char *input, int *count) {
   if (input == NULL || input[0] != '*') {
     *count = 0;
-    return NULL;  // not an array, invalid command
+    return NULL; // not an array, invalid command
   }
 
   // parse the number of elements in the array
@@ -145,7 +145,8 @@ char **deserialize_command(const char *input, int *count) {
   for (int i = 0; i < *count; i++) {
     if (current[0] != '$') {
       // expected a bulk string, but did not find one
-      for (int j = 0; j < i; j++) free(result[j]);
+      for (int j = 0; j < i; j++)
+        free(result[j]);
       free(result);
       *count = 0;
       return NULL;
@@ -162,15 +163,16 @@ char **deserialize_command(const char *input, int *count) {
       // allocate memory for this string and copy it
       result[i] = (char *)malloc(len + 1);
       if (result[i] == NULL) {
-        for (int j = 0; j < i; j++) free(result[j]);
+        for (int j = 0; j < i; j++)
+          free(result[j]);
         free(result);
         *count = 0;
         return NULL;
       }
       strncpy(result[i], current, len);
-      result[i][len] = '\0';  // null terminate
+      result[i][len] = '\0'; // null terminate
 
-      current += len + 2;  // skip past the string and the "\r\n"
+      current += len + 2; // skip past the string and the "\r\n"
     }
   }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1,8 +1,12 @@
 #include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/epoll.h>
 #include <sys/socket.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "khash.h"
@@ -10,6 +14,7 @@
 
 #define DEFAULT_PORT 6379
 #define BUFFER_SIZE 1024
+#define MAX_EVENTS 50
 
 typedef enum { TYPE_STRING } ValueType;
 
@@ -106,74 +111,114 @@ int start_server() {
     exit(EXIT_FAILURE);
   }
 
-  printf("server started listening");
+  printf("server started listening\n");
+
+  int epfd = epoll_create(1);
+  if (epfd == -1) {
+    perror("epoll_create1 failed");
+    exit(EXIT_FAILURE);
+  }
+
+  struct epoll_event event;
+  event.events = EPOLLIN;  // EPOLLIN is the flag for read events
+  event.data.fd = SocketFD;
+
+  if (epoll_ctl(epfd, EPOLL_CTL_ADD, SocketFD, &event) == 1) {
+    perror("epoll_ctl failed");
+    exit(EXIT_FAILURE);
+  }
+
+  struct epoll_event events[MAX_EVENTS];
+  int num_events;
 
   for (;;) {
-    int ConnectFD = accept(SocketFD, NULL, NULL);
-
-    if (ConnectFD == -1) {
-      perror("accept failed");
-      close(SocketFD);
+    num_events = epoll_wait(epfd, events, MAX_EVENTS, -1);
+    if (num_events == -1) {
+      perror("epoll_wait failed");
       exit(EXIT_FAILURE);
     }
 
-    char buffer[BUFFER_SIZE];
-    ssize_t bytes_received;
-
-    // read from the client
-    bytes_received = recv(ConnectFD, buffer, BUFFER_SIZE - 1, 0);
-    if (bytes_received > 0) {
-      buffer[bytes_received] = '\0';  // null terminate the received string
-      printf("Received: %s\n", buffer);
-
-      // deserialize received RESP data
-      int count;
-      char **parsed_command = deserialize_command(buffer, &count);
-      if (parsed_command && count > 0) {
-        const char *response;
-        // check if the received message is ping
-        if (strcmp(parsed_command[0], "PING") == 0) {
-          response = serialize_simple_string("PONG");
-        } else if (strcmp(parsed_command[0], "ECHO") == 0 && count > 1) {
-          response = serialize_bulk_string(parsed_command[1]);
-        } else if (strcmp(parsed_command[0], "SET") == 0 && count > 2) {
-          set_value(h, parsed_command[1], parsed_command[2], TYPE_STRING);
-          response = serialize_simple_string("OK");
-        } else if (strcmp(parsed_command[0], "GET") == 0 && count > 1) {
-          RedisValue *redis_value = get_value(h, parsed_command[1]);
-          if (redis_value == NULL) {
-            response = serialize_bulk_string(NULL);
-          } else {
-            response = serialize_bulk_string(redis_value->data.str);
-          }
-        } else {
-          response = serialize_error("ERR unknown command");
+    // iterate through the events
+    for (int i = 0; i < num_events; i++) {
+      if (events[i].data.fd ==
+          SocketFD) {  // server socket is ready, new connection
+        int ConnectFD = accept(SocketFD, NULL, NULL);
+        if (ConnectFD == -1) {
+          perror("accept failed");
+          close(SocketFD);
+          exit(EXIT_FAILURE);
         }
-        if (response) {
-          ssize_t bytes_sent = send(ConnectFD, response, strlen(response), 0);
-          if (bytes_sent < 0) {
-            perror("send failed");
-          } else {
-            printf("Sent: %s\n", response);
-          }
+
+        int optval = 1;
+        setsockopt(ConnectFD, IPPROTO_TCP, TCP_NODELAY, &optval,
+                   sizeof(optval));
+
+        event.events = EPOLLIN;
+        event.data.fd = ConnectFD;
+
+        if (epoll_ctl(epfd, EPOLL_CTL_ADD, ConnectFD, &event) == -1) {
+          perror("epoll_ctl failed");
+          exit(EXIT_FAILURE);
         }
-        // free the deserialized command
-        free_command(parsed_command, count);
       } else {
-        printf("Invalid command received\n");
-      }
-    } else if (bytes_received == 0) {
-      printf("Client disconnected\n");
-    } else {
-      printf("read failed");
-    }
+        char buffer[BUFFER_SIZE];
+        ssize_t bytes_received;
 
-    // if (shutdown(ConnectFD, SHUT_RDWR) == -1) {
-    //   perror("shutdown failed");
-    // }
-    close(ConnectFD);
+        // read from the client
+        bytes_received = recv(events[i].data.fd, buffer, BUFFER_SIZE - 1, 0);
+        if (bytes_received > 0) {
+          buffer[bytes_received] = '\0';  // null terminate the received string
+          printf("Received: %s\n", buffer);
+
+          // Check for PING command
+          if (strcmp(buffer, "PING\r\n") == 0 ||
+              strcmp(buffer, "*1\r\n$4\r\nPING\r\n") == 0) {
+            const char *response = serialize_simple_string("PONG");
+            send_response(events[i].data.fd, response);
+          } else {
+            // deserialize received RESP data
+            int count;
+            char **parsed_command = deserialize_command(buffer, &count);
+            if (parsed_command && count > 0) {
+              const char *response;
+              if (strcmp(parsed_command[0], "ECHO") == 0 && count > 1) {
+                response = serialize_bulk_string(parsed_command[1]);
+              } else if (strcmp(parsed_command[0], "SET") == 0 && count > 2) {
+                set_value(h, parsed_command[1], parsed_command[2], TYPE_STRING);
+                response = serialize_simple_string("OK");
+              } else if (strcmp(parsed_command[0], "GET") == 0 && count > 1) {
+                RedisValue *redis_value = get_value(h, parsed_command[1]);
+                if (redis_value == NULL) {
+                  response = serialize_bulk_string(NULL);
+                } else {
+                  response = serialize_bulk_string(redis_value->data.str);
+                }
+              } else {
+                response = serialize_error("ERR unknown command");
+              }
+              if (response) {
+                send_response(events[i].data.fd, response);
+              }
+              // free the deserialized command
+              free_command(parsed_command, count);
+            } else {
+              printf("Invalid command received\n");
+            }
+          }
+        } else if (bytes_received == 0) {
+          printf("Client disconnected\n");
+          close(events[i].data.fd);
+          epoll_ctl(epfd, EPOLL_CTL_DEL, events[i].data.fd, NULL);
+        } else {
+          printf("read failed");
+          close(events[i].data.fd);
+          epoll_ctl(epfd, EPOLL_CTL_DEL, events[i].data.fd, NULL);
+        }
+      }
+    }
   }
 
+  close(epfd);
   close(SocketFD);
   cleanup_hash(h);
   return EXIT_SUCCESS;

--- a/test/resp_test.cc
+++ b/test/resp_test.cc
@@ -4,63 +4,75 @@ extern "C" {
 #include <gtest/gtest.h>
 
 TEST(SerializeTest, HandleSimpleString) {
-  const char* input = "Ok";
-  char* result = serialize_simple_string(input);
+  const char *input = "Ok";
+  char *result = serialize_simple_string(input);
   EXPECT_STREQ(result, "+Ok\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleError) {
-  const char* input = "Error message";
-  char* result = serialize_error(input);
+  const char *input = "Error message";
+  char *result = serialize_error(input);
   EXPECT_STREQ(result, "-Error message\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleInteger) {
   const int input = 55;
-  char* result = serialize_integer(input);
+  char *result = serialize_integer(input);
   EXPECT_STREQ(result, ":55\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleBulkString) {
-  const char* input = "Hello";
-  char* result = serialize_bulk_string(input);
+  const char *input = "Hello";
+  char *result = serialize_bulk_string(input);
   EXPECT_STREQ(result, "$5\r\nHello\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleNullBulkString) {
-  char* result = serialize_bulk_string(NULL);
+  char *result = serialize_bulk_string(NULL);
   EXPECT_STREQ(result, "$-1\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleArrayOfBulkStrings) {
-  const char* input[] = {"hello", "world"};
-  char* result = serialize_array(input, 2);
+  const char *input[] = {"hello", "world"};
+  char *result = serialize_array(input, 2);
   EXPECT_STREQ(result, "*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleEmptyArray) {
-  char* result = serialize_array(NULL, 0);
+  char *result = serialize_array(NULL, 0);
   EXPECT_STREQ(result, "*-1\r\n");
   free(result);
 }
 
 TEST(SerializeTest, HandleArrayWithNullElements) {
-  const char* input[] = {"hello", NULL, "world"};
-  char* result = serialize_array(input, 3);
+  const char *input[] = {"hello", NULL, "world"};
+  char *result = serialize_array(input, 3);
   EXPECT_STREQ(result, "*3\r\n$5\r\nhello\r\n$-1\r\n$5\r\nworld\r\n");
   free(result);
 }
 
-TEST(DeserializeCommandTest, ValidCommand) {
-  const char* input = "*2\r\n$4\r\necho\r\n$11\r\nhello world\r\n";
+TEST(DeserializeCommandTest, PingInline) {
+  const char *input = "PING\n";
   int count;
-  char** result = deserialize_command(input, &count);
+  char **result = deserialize_command(input, &count);
+
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(count, 1);
+  EXPECT_STREQ(result[0], "PING");
+
+  free_command(result, count);
+}
+
+TEST(DeserializeCommandTest, ValidCommand) {
+  const char *input = "*2\r\n$4\r\necho\r\n$11\r\nhello world\r\n";
+  int count;
+  char **result = deserialize_command(input, &count);
 
   ASSERT_NE(result, nullptr);
   EXPECT_EQ(count, 2);
@@ -71,9 +83,9 @@ TEST(DeserializeCommandTest, ValidCommand) {
 }
 
 TEST(DeserializeCommandTest, NullBulkString) {
-  const char* input = "*3\r\n$3\r\nget\r\n$-1\r\n$4\r\nName\r\n";
+  const char *input = "*3\r\n$3\r\nget\r\n$-1\r\n$4\r\nName\r\n";
   int count;
-  char** result = deserialize_command(input, &count);
+  char **result = deserialize_command(input, &count);
 
   ASSERT_NE(result, nullptr);
   EXPECT_STREQ(result[0], "get");


### PR DESCRIPTION
I implemented concurrent handling of clients using `epoll` to achieve efficient IO multiplexing. This has enabled my server to support 30,000 requests without pipelining. Currently, the server is bottlenecked by sending the response with the `send` call, however, this will be addressed in a future issue.

I also added some fixes:
- Fix: Ensure memory allocated to the command is free'd after processing a command

And some code formatting changes:
- Added .clang-format for consistent formatting
- Formatted most of the file