### PR TITLE
feat: Implement key expiry options

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -20,11 +20,22 @@ typedef struct {
   union {
     char *str;
   } data;
+  time_t expiration;
 } RedisValue;
+
+typedef struct {
+  long long expiration; // expiration time in milliseconds sinch epoch
+  int nx;               // flag for NX option
+  int xx;               // flag for XX option
+  int keepttl;          // flag for KEEPTTL option
+  int get;              // flag for get option
+} SetOptions;
 
 KHASH_MAP_INIT_STR(redis_hash, RedisValue *)
 
-void set_value(khash_t(redis_hash) * h, const char *key, const void *value, ValueType type);
+long long current_time_millis();
+void set_value(khash_t(redis_hash) * h, const char *key, const void *value, ValueType type,
+               long long expiration);
 RedisValue *get_value(khash_t(redis_hash) * h, const char *key);
 void cleanup_hash(khash_t(redis_hash) * h);
 void handle_command(struct CommandHandler *ch);

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -16,7 +16,7 @@ protected:
 TEST_F(DictionaryTest, SetValueString) {
   const char *key = "test_key";
   const char *value = "test_value";
-  set_value(h, key, value, TYPE_STRING);
+  set_value(h, key, value, TYPE_STRING, 0);
 
   khiter_t k = kh_get(redis_hash, h, key);
   ASSERT_NE(k, kh_end(h));
@@ -30,7 +30,7 @@ TEST_F(DictionaryTest, OverwriteExistingStringValue) {
   const char *initial_value = "initial_value";
   const char *new_value = "new_value";
 
-  set_value(h, key, initial_value, TYPE_STRING);
+  set_value(h, key, initial_value, TYPE_STRING, 0);
 
   khiter_t k = kh_get(redis_hash, h, key);
   ASSERT_NE(k, kh_end(h));
@@ -38,7 +38,7 @@ TEST_F(DictionaryTest, OverwriteExistingStringValue) {
   EXPECT_EQ(rv->type, TYPE_STRING);
   EXPECT_STREQ(rv->data.str, initial_value);
 
-  set_value(h, key, new_value, TYPE_STRING);
+  set_value(h, key, new_value, TYPE_STRING, 0);
   k = kh_get(redis_hash, h, key);
   ASSERT_NE(k, kh_end(h));
   rv = kh_value(h, k);
@@ -49,7 +49,7 @@ TEST_F(DictionaryTest, OverwriteExistingStringValue) {
 TEST_F(DictionaryTest, GetValueString) {
   const char *key = "test_key";
   const char *value = "test_value";
-  set_value(h, key, value, TYPE_STRING);
+  set_value(h, key, value, TYPE_STRING, 0);
 
   RedisValue *retrieved_value = get_value(h, key);
   ASSERT_NE(retrieved_value, nullptr);
@@ -60,4 +60,81 @@ TEST_F(DictionaryTest, GetValueString) {
 TEST_F(DictionaryTest, GetValueKeyNotFound) {
   RedisValue *retrieved_value = get_value(h, "test_key");
   ASSERT_EQ(retrieved_value, nullptr);
+}
+
+TEST_F(DictionaryTest, SetValueWithExpiration) {
+  const char *key = "expiring_key";
+  const char *value = "expiring_value";
+  long long expiration = current_time_millis() + 1000; // 1 second from now
+  set_value(h, key, value, TYPE_STRING, expiration);
+
+  RedisValue *retrieved_value = get_value(h, key);
+  ASSERT_NE(retrieved_value, nullptr);
+  EXPECT_EQ(retrieved_value->type, TYPE_STRING);
+  EXPECT_STREQ(retrieved_value->data.str, value);
+  EXPECT_EQ(retrieved_value->expiration, expiration);
+}
+
+TEST_F(DictionaryTest, GetExpiredValue) {
+  const char *key = "expired_key";
+  const char *value = "expired_value";
+  long long expiration = current_time_millis() - 1000; // 1 second ago
+  set_value(h, key, value, TYPE_STRING, expiration);
+
+  RedisValue *retrieved_value = get_value(h, key);
+  ASSERT_EQ(retrieved_value, nullptr);
+
+  // verify that the key has been removed from the hash table
+  khiter_t k = kh_get(redis_hash, h, key);
+  EXPECT_EQ(k, kh_end(h));
+}
+
+TEST_F(DictionaryTest, UpdateExpirationTime) {
+  const char *key = "update_expiry_key";
+  const char *value = "update_expiry_value";
+  long long initial_expiration = current_time_millis() + 1000; // 1 second from now
+  set_value(h, key, value, TYPE_STRING, initial_expiration);
+
+  long long new_expiration = current_time_millis() + 5000; // 5 seconds from now
+  set_value(h, key, value, TYPE_STRING, new_expiration);
+
+  RedisValue *retrieved_value = get_value(h, key);
+  ASSERT_NE(retrieved_value, nullptr);
+  EXPECT_EQ(retrieved_value->expiration, new_expiration);
+}
+
+TEST_F(DictionaryTest, RemoveExpiration) {
+  const char *key = "remove_expiry_key";
+  const char *value = "remove_expiry_value";
+  long long initial_expiration = current_time_millis() + 1000; // 1 second from now
+  set_value(h, key, value, TYPE_STRING, initial_expiration);
+
+  set_value(h, key, value, TYPE_STRING, 0); // set without expiration
+
+  RedisValue *retrieved_value = get_value(h, key);
+  ASSERT_NE(retrieved_value, nullptr);
+  EXPECT_EQ(retrieved_value->expiration, 0);
+}
+
+TEST_F(DictionaryTest, MultipleKeysWithExpiration) {
+  const char *key1 = "key1";
+  const char *key2 = "key2";
+  const char *key3 = "key3";
+  const char *value = "value";
+
+  long long now = current_time_millis();
+  set_value(h, key1, value, TYPE_STRING, now - 1000); // already expired
+  set_value(h, key2, value, TYPE_STRING, now + 1000); // expires in 1 second
+  set_value(h, key3, value, TYPE_STRING, 0);          // no expiration
+
+  EXPECT_EQ(get_value(h, key1), nullptr);
+  EXPECT_NE(get_value(h, key2), nullptr);
+  EXPECT_NE(get_value(h, key3), nullptr);
+
+  // wait for key2 to expire
+  usleep(1100000); // sleep for 1.1 seconds
+
+  EXPECT_EQ(get_value(h, key1), nullptr);
+  EXPECT_EQ(get_value(h, key2), nullptr);
+  EXPECT_NE(get_value(h, key3), nullptr);
 }

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -103,13 +103,14 @@ TEST_F(DictionaryTest, UpdateExpirationTime) {
   EXPECT_EQ(retrieved_value->expiration, new_expiration);
 }
 
-TEST_F(DictionaryTest, RemoveExpiration) {
+TEST_F(DictionaryTest, RemoveExpirationAndPersist) {
   const char *key = "remove_expiry_key";
   const char *value = "remove_expiry_value";
   long long initial_expiration = current_time_millis() + 1000; // 1 second from now
   set_value(h, key, value, TYPE_STRING, initial_expiration);
 
   set_value(h, key, value, TYPE_STRING, 0); // set without expiration
+  usleep(1100000); // sleep for 1.1 seconds, to verify if key persists after removing expiration
 
   RedisValue *retrieved_value = get_value(h, key);
   ASSERT_NE(retrieved_value, nullptr);


### PR DESCRIPTION
Implement Redis command key expiry options EX, PX, EXAT, PXAT, XX, NN, KEEPTTL, and GET
Add unit tests for testing the functionality of setting expiration, removing it, modifying it. Update existing tests, to accommodate expiry parameter variable passed set_value function.