### PR TITLE
fix: Fix memory issues, memory allocation/freeing issues

### DIFF
--- a/src/redis-server.c
+++ b/src/redis-server.c
@@ -89,8 +89,8 @@ void process_client_input(Client *client, int epfd) {
 }
 
 void handle_client_disconnection(Client *client, int epfd) {
-  destroy_client(client);
   epoll_ctl(epfd, EPOLL_CTL_DEL, client->fd, NULL);
+  destroy_client(client);
 }
 
 volatile sig_atomic_t stop_server = 0;


### PR DESCRIPTION
- Ensure ch->args array is properly allocated with sizeof(char*). ch->args array holds arguments after parsing RESP commands
- Fix calls to realloc ch->args with length of longer length instead of initial capacity
- Ensure arguments are freed after a command has been processed