### PR TITLE
Implement LPUSH and RPUSH commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(redis_lite
     src/command_handler.c
     src/commands.c
     src/ring_buffer.c
+    src/linked_list.c
     src/util.c
     src/database.c
 )

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -25,6 +25,10 @@ CommandType get_command_type(char *command) {
     return CMD_INCR;
   else if (strcmp(command, "DECR") == 0)
     return CMD_DECR;
+  else if (strcmp(command, "LPUSH") == 0)
+    return CMD_LPUSH;
+  else if (strcmp(command, "RPUSH") == 0)
+    return CMD_RPUSH;
   else
     return CMD_UNKNOWN;
 }
@@ -57,6 +61,12 @@ void handle_command(CommandHandler *ch) {
     break;
   case CMD_DECR:
     handle_decr(ch);
+    break;
+  case CMD_LPUSH:
+    handle_lpush(ch);
+    break;
+  case CMD_RPUSH:
+    handle_rpush(ch);
     break;
   default:
     add_error_reply(ch->client, "ERR unknown command");

--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -18,6 +18,8 @@ typedef enum {
   CMD_DEL,
   CMD_INCR,
   CMD_DECR,
+  CMD_LPUSH,
+  CMD_RPUSH,
   CMD_UNKNOWN
 } CommandType;
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -20,6 +20,8 @@ void handle_exist(CommandHandler *ch);
 void handle_delete(CommandHandler *ch);
 void handle_incr(CommandHandler *ch);
 void handle_decr(CommandHandler *ch);
+void handle_lpush(CommandHandler *ch);
+void handle_rpush(CommandHandler *ch);
 
 void add_error_reply(Client *client, const char *str);
 

--- a/src/database.c
+++ b/src/database.c
@@ -18,6 +18,8 @@ void destroy_redis_hash(khash_t(redis_hash) * h) {
       RedisValue *rv = kh_value(h, k);
       if (rv->type == TYPE_STRING) {
         free(rv->data.str); // free the string data
+      } else if (rv->type == TYPE_LIST) {
+        destroy_list(rv->data.str);
       }
       free(rv);
     }

--- a/src/database.h
+++ b/src/database.h
@@ -1,15 +1,17 @@
 #ifndef DATABASE_H
 #define DATABASE_H
 #include "khash.h"
+#include "linked_list.h"
 #include "sys/time.h"
 #include <stdbool.h>
 
-typedef enum { TYPE_STRING } ValueType;
+typedef enum { TYPE_STRING, TYPE_LIST } ValueType;
 
 typedef struct {
   ValueType type;
   union {
     char *str;
+    List list;
   } data;
   time_t expiration;
 } RedisValue;
@@ -18,8 +20,11 @@ KHASH_MAP_INIT_STR(redis_hash, RedisValue *)
 
 void redis_db_create();
 void redis_db_destroy();
-void redis_db_set(const char *key, const char *value, ValueType type, long long expiration);
+void redis_db_set(const char *key, const void *value, ValueType type, long long expiration);
 RedisValue *redis_db_get(const char *key);
 bool redis_db_exist(const char *key);
 void redis_db_delete(const char *key);
+int redis_db_lpush(const char *key, const char *item, int *length);
+int redis_db_rpush(const char *key, const char *item, int *length);
+
 #endif // DATABASE_H

--- a/src/linked_list.c
+++ b/src/linked_list.c
@@ -1,0 +1,121 @@
+#include "linked_list.h"
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct Node {
+  char *data;
+  struct Node *prev;
+  struct Node *next;
+} Node;
+
+struct list_struct {
+  Node *head;
+  Node *tail;
+  size_t length;
+};
+
+List create_list() {
+  List list = malloc(sizeof(struct list_struct));
+  if (!list) {
+    return NULL;
+  }
+  list->head = NULL;
+  list->tail = NULL;
+  return list;
+}
+
+void destroy_list(List list) {
+  if (list == NULL) {
+    return;
+  }
+
+  Node *cur = list->head;
+  while (cur != NULL) {
+    Node *temp = cur->next;
+    cur->prev = NULL;
+    cur->next = NULL;
+    free(cur->data);
+    free(cur);
+    cur = temp;
+  }
+  free(list);
+}
+
+int lpush(List list, const char *data, int *length) {
+  if (list == NULL || data == NULL) {
+    return 0;
+  }
+
+  Node *new_node = malloc(sizeof(Node));
+  if (new_node == NULL) {
+    return 0;
+  }
+  new_node->data = strdup(data);
+  if (new_node->data == NULL) {
+    free(new_node); // clean up allocated node if strdup fails
+    return 0;
+  }
+
+  // list is empty
+  if (list->head == NULL && list->tail == NULL) {
+    list->head = new_node;
+    list->tail = new_node;
+    new_node->prev = NULL;
+    new_node->next = NULL;
+    list->length = 1;
+    *length = list->length;
+    return 0;
+  }
+
+  new_node->next = list->head;
+  new_node->prev = NULL;
+  list->head->prev = new_node;
+  list->head = new_node;
+  list->length++;
+  *length = list->length;
+  return 0;
+}
+
+int rpush(List list, const char *data, int *length) {
+  if (list == NULL || data == NULL) {
+    return 0;
+  }
+
+  Node *new_node = malloc(sizeof(Node));
+  if (new_node == NULL) {
+    return 0;
+  }
+  new_node->data = strdup(data);
+  if (new_node->data == NULL) {
+    free(new_node); // clean up allocated node if strdup fails
+    return 0;
+  }
+
+  // list is empty
+  if (list->head == NULL && list->tail == NULL) {
+    list->head = new_node;
+    list->tail = new_node;
+    new_node->prev = NULL;
+    new_node->next = NULL;
+    list->length = 1;
+    *length = list->length;
+    return 0;
+  }
+
+  new_node->prev = list->tail;
+  new_node->next = NULL;
+  list->tail->next = new_node;
+  list->tail = new_node;
+  list->length++;
+  *length = list->length;
+  return 0;
+}
+
+size_t get_list_length(List list) {
+  if (list == NULL) {
+    return 0;
+  }
+  return list->length;
+}

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -1,0 +1,14 @@
+#ifndef LINKED_LIST_H
+#define LINKED_LIST_H
+#include "stddef.h"
+
+struct list_struct;
+typedef struct list_struct *List;
+
+List create_list();
+void destroy_list(List list);
+int lpush(List list, const char *data, int *length);
+int rpush(List list, const char *data, int *length);
+size_t get_list_length(List list);
+
+#endif // LINKED_LIST_H

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,7 @@
 #define ERR_NONE 0
 #define ERR_SYNTAX -1
 #define ERR_VALUE -2
+#define ERR_TYPE_MISMATCH -3
 
 long long current_time_millis();
 int parse_integer(const char *str, long *result);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,7 @@
+include(GoogleTest)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
-add_executable(resp_test 
-    resp_test.cc 
-    ${CMAKE_SOURCE_DIR}/src/resp.c
-    ${CMAKE_SOURCE_DIR}/src/ring_buffer.c
-    ${CMAKE_SOURCE_DIR}/test/mock_handler.c
-
-)
-add_executable(ring_buffer_test ring_buffer_test.cc ${CMAKE_SOURCE_DIR}/src/ring_buffer.c)
-add_executable(dictionary_test
-dictionary_test.cc 
+set(COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/resp.c
     ${CMAKE_SOURCE_DIR}/src/ring_buffer.c
     ${CMAKE_SOURCE_DIR}/src/command_handler.c
@@ -17,48 +9,29 @@ dictionary_test.cc
     ${CMAKE_SOURCE_DIR}/src/client.c
     ${CMAKE_SOURCE_DIR}/src/commands.c
     ${CMAKE_SOURCE_DIR}/src/util.c
-)
-add_executable(command_test
-command_test.cc
-    ${CMAKE_SOURCE_DIR}/src/resp.c
-    ${CMAKE_SOURCE_DIR}/src/ring_buffer.c
-    ${CMAKE_SOURCE_DIR}/src/command_handler.c
-    ${CMAKE_SOURCE_DIR}/src/database.c
-    ${CMAKE_SOURCE_DIR}/src/client.c
-    ${CMAKE_SOURCE_DIR}/src/commands.c
-    ${CMAKE_SOURCE_DIR}/src/util.c
+    ${CMAKE_SOURCE_DIR}/src/linked_list.c
 )
 
-target_link_libraries(
-  resp_test
-  GTest::gtest_main
+set(TEST_EXECUTABLES
+    resp_test
+    ring_buffer_test
+    dictionary_test
+    command_test
+    linked_list_test
 )
 
-target_link_libraries(
-  ring_buffer_test
-  GTest::gtest_main
-)
+function(add_gtest_executable name)
+    add_executable(${name} ${name}.cc ${ARGN})
+    target_link_libraries(${name} PRIVATE GTest::gtest_main)
+    target_include_directories(${name} PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    gtest_discover_tests(${name})
+endfunction()
 
-target_link_libraries(
-  dictionary_test
-  GTest::gtest_main
-)
-
-target_link_libraries(
-  command_test
-  GTest::gtest_main
-)
-
-include(GoogleTest)
-gtest_discover_tests(resp_test)
-gtest_discover_tests(ring_buffer_test)
-gtest_discover_tests(dictionary_test)
-gtest_discover_tests(command_test)
-
-target_include_directories(resp_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(ring_buffer_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(dictionary_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(command_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+add_gtest_executable(resp_test ${COMMON_SOURCES} ${CMAKE_SOURCE_DIR}/test/mock_handler.c)
+add_gtest_executable(ring_buffer_test ${CMAKE_SOURCE_DIR}/src/ring_buffer.c)
+add_gtest_executable(dictionary_test ${COMMON_SOURCES})
+add_gtest_executable(command_test ${COMMON_SOURCES})
+add_gtest_executable(linked_list_test ${CMAKE_SOURCE_DIR}/src/linked_list.c)
 
 
 

--- a/test/command_test.cc
+++ b/test/command_test.cc
@@ -221,3 +221,56 @@ TEST_F(CommandTest, DecrWithInvalidValue) {
   ExecuteCommand({"DECR", "invalid_key"});
   EXPECT_EQ(GetReply(), "-ERR value is not an integer\r\n");
 }
+
+TEST_F(CommandTest, LpushCommand) {
+  ExecuteCommand({"LPUSH", "mylist", "car"});
+  EXPECT_EQ(GetReply(), ":1\r\n");
+
+  ExecuteCommand({"LPUSH", "mylist", "dog"});
+  EXPECT_EQ(GetReply(), ":2\r\n");
+}
+
+TEST_F(CommandTest, LpushCommand_MultipleItems) {
+  ExecuteCommand({"LPUSH", "mylist", "car", "dog", "house"});
+  EXPECT_EQ(GetReply(), ":3\r\n");
+}
+
+TEST_F(CommandTest, RpushCommand_MultipleItems) {
+  ExecuteCommand({"LPUSH", "mylist", "car", "dog", "house"});
+  EXPECT_EQ(GetReply(), ":3\r\n");
+}
+
+TEST_F(CommandTest, RpushCommand) {
+  ExecuteCommand({"RPUSH", "mylist", "car"});
+  EXPECT_EQ(GetReply(), ":1\r\n");
+
+  ExecuteCommand({"RPUSH", "mylist", "dog"});
+  EXPECT_EQ(GetReply(), ":2\r\n");
+}
+
+TEST_F(CommandTest, GetStringOnList_ShouldReturnError) {
+  ExecuteCommand({"LPUSH", "mylist", "car"});
+  EXPECT_EQ(GetReply(), ":1\r\n");
+
+  ExecuteCommand({"GET", "mylist"});
+  EXPECT_EQ(GetReply(), "-ERR Operation against a key holding the wrong kind of value\r\n");
+}
+
+TEST_F(CommandTest, LpushRpushOnStringValue_ShouldReturnError) {
+  ExecuteCommand({"SET", "mylist", "x"});
+  EXPECT_EQ(GetReply(), "+OK\r\n");
+
+  ExecuteCommand({"LPUSH", "mylist", "car"});
+  EXPECT_EQ(GetReply(), "-ERR Operation against a key holding the wrong kind of value\r\n");
+
+  ExecuteCommand({"RPUSH", "mylist", "car"});
+  EXPECT_EQ(GetReply(), "-ERR Operation against a key holding the wrong kind of value\r\n");
+}
+
+TEST_F(CommandTest, LpushAndDelete_ShouldDelete) {
+  ExecuteCommand({"LPUSH", "mylist", "car"});
+  EXPECT_EQ(GetReply(), ":1\r\n");
+
+  ExecuteCommand({"DEL", "mylist", "car"});
+  EXPECT_EQ(GetReply(), "+OK\r\n");
+}

--- a/test/linked_list_test.cc
+++ b/test/linked_list_test.cc
@@ -1,0 +1,43 @@
+extern "C" {
+#include "linked_list.h"
+}
+#include <gtest/gtest.h>
+
+#include "linked_list.h"
+#include <gtest/gtest.h>
+
+class LinkedListTest : public ::testing::Test {
+protected:
+  List list;
+
+  void SetUp() override { list = create_list(); }
+
+  void TearDown() override { destroy_list(list); }
+};
+
+TEST_F(LinkedListTest, CreateList) {
+  EXPECT_NE(list, nullptr);
+  EXPECT_EQ(get_list_length(list), 0);
+}
+
+TEST_F(LinkedListTest, LPush) {
+  int length;
+  EXPECT_EQ(lpush(list, "test", &length), 0);
+  EXPECT_EQ(length, 1);
+  EXPECT_EQ(get_list_length(list), 1);
+}
+
+TEST_F(LinkedListTest, RPush) {
+  int length;
+  EXPECT_EQ(rpush(list, "test", &length), 0);
+  EXPECT_EQ(length, 1);
+  EXPECT_EQ(get_list_length(list), 1);
+}
+
+TEST_F(LinkedListTest, LpushAndRPush) {
+  int length;
+  EXPECT_EQ(lpush(list, "first", &length), 0);
+  EXPECT_EQ(rpush(list, "second", &length), 0);
+  EXPECT_EQ(length, 2);
+  EXPECT_EQ(get_list_length(list), 2);
+}


### PR DESCRIPTION
Implement the LPUSH and RPUSH commands:
- LPUSH pushes to the front of a list
- RPUSH pushes to the back of a list
- If a key is not associated with a value, it will create a new list and perform the operation
- Both operations return the length of the list after the operation is complete

Benchmark results:
![image](https://github.com/user-attachments/assets/110a99a0-4856-4718-8aff-1f367e717f94)

Details:
- Add custom doubly linked list implementation with tests
- Ensure lpush and rpush operations return length of the list after operation
- Handle errors such as operation on key with wrong type of value (ex: GET on a list, or LPUSH/RPUSH on an existing key associated with a string value)
- Rename database get operation to get_string for clarity
- Add dictionary tests related to lpush and rpush operations
- Add integration tests for LPUSH and RPUSH commands