### PR TITLE
feat: Implement RDB persistence with SAVE command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(redis_lite
     src/linked_list.c
     src/util.c
     src/database.c
+    src/rdb.c
 )
 
 # GoogleTest requires at least C++14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(redis_lite
     src/redis-server.c
     src/client.c
     src/command_handler.c
-    src/commands.c
+    src/commands.c 
     src/ring_buffer.c
     src/linked_list.c
     src/util.c

--- a/src/client.c
+++ b/src/client.c
@@ -1,4 +1,5 @@
 #include "client.h"
+#include "database.h"
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -33,6 +34,8 @@ Client *create_client(int fd, Handler *handler) {
 
   return client;
 }
+
+void select_client_db(Client *client, redis_db_t *db) { client->db = db; }
 
 void destroy_client(Client *client) {
   close(client->fd);

--- a/src/client.h
+++ b/src/client.h
@@ -1,6 +1,7 @@
 #ifndef CLIENT_H
 #define CLIENT_H
 
+#include "database.h"
 #include "handler.h"
 #include "resp.h"        // Include this for the Parser definition
 #include "ring_buffer.h" // Include this if ring_buffer is defined in a separate header
@@ -12,9 +13,11 @@ typedef struct Client {
   ring_buffer input_buffer;
   ring_buffer output_buffer;
   struct Parser *parser;
+  redis_db_t *db; // currently selected database
 } Client;
 
 Client *create_client(int fd, Handler *handler);
+void select_client_db(Client *client, redis_db_t *db);
 void flush_client_output(Client *client);
 void destroy_client(Client *client);
 

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -31,6 +31,8 @@ CommandType get_command_type(char *command) {
     return CMD_RPUSH;
   else if (strcmp(command, "LRANGE") == 0)
     return CMD_LRANGE;
+  else if (strcmp(command, "CONFIG") == 0)
+    return CMD_CONFIG;
   else
     return CMD_UNKNOWN;
 }
@@ -72,6 +74,9 @@ void handle_command(CommandHandler *ch) {
     break;
   case CMD_LRANGE:
     handle_lrange(ch);
+    break;
+  case CMD_CONFIG:
+    handle_config(ch);
     break;
   default:
     add_error_reply(ch->client, "ERR unknown command");

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -6,7 +6,6 @@
 
 #include "command_handler.h"
 #include "commands.h"
-#include "resp.h"
 
 CommandType get_command_type(char *command) {
   if (strcmp(command, "PING") == 0)
@@ -33,6 +32,11 @@ CommandType get_command_type(char *command) {
     return CMD_LRANGE;
   else if (strcmp(command, "CONFIG") == 0)
     return CMD_CONFIG;
+  else if (strcmp(command, "SAVE") == 0) {
+    printf("RECEIVED COMMAND SAVE\n");
+    return CMD_SAVE;
+  } else if (strcmp(command, "DBSIZE") == 0)
+    return CMD_DBSIZE;
   else
     return CMD_UNKNOWN;
 }
@@ -77,6 +81,12 @@ void handle_command(CommandHandler *ch) {
     break;
   case CMD_CONFIG:
     handle_config(ch);
+    break;
+  case CMD_SAVE:
+    handle_save(ch);
+    break;
+  case CMD_DBSIZE:
+    handle_dbsize(ch);
     break;
   default:
     add_error_reply(ch->client, "ERR unknown command");

--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -22,6 +22,8 @@ typedef enum {
   CMD_RPUSH,
   CMD_LRANGE,
   CMD_CONFIG,
+  CMD_SAVE,
+  CMD_DBSIZE,
   CMD_UNKNOWN
 } CommandType;
 

--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -21,6 +21,7 @@ typedef enum {
   CMD_LPUSH,
   CMD_RPUSH,
   CMD_LRANGE,
+  CMD_CONFIG,
   CMD_UNKNOWN
 } CommandType;
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -8,6 +8,11 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#define MAX_PATH_LENGTH 256
+
+extern char dir[MAX_PATH_LENGTH];
+extern char dbfilename[MAX_PATH_LENGTH];
+
 void add_simple_string_reply(Client *client, const char *str) {
   write_begin_simple_string(client->output_buffer);
   write_chars(client->output_buffer, str);
@@ -338,4 +343,32 @@ void handle_lrange(CommandHandler *ch) {
 
   add_array_reply(ch->client, range, range_length);
   cleanup_lrange_result(range, range_length);
+}
+
+void handle_config(CommandHandler *ch) {
+  if (ch->arg_count < 3) {
+    add_error_reply(ch->client, "ERR wrong number of arguments for 'config get' command");
+    return;
+  }
+
+  int param_count = ch->arg_count - 2;
+  char *response[param_count * 2];
+  int response_index = 0;
+
+  if (strcmp(ch->args[1], "GET") == 0) {
+    for (int i = 0; i < param_count; i++) {
+      const char *param = ch->args[i + 2];
+      if (strcmp(param, "dir") == 0) {
+        response[response_index++] = "dir";
+        response[response_index++] = dir;
+      } else if (strcmp(param, "dbfilename") == 0) {
+        response[response_index++] = "dbfilename";
+        response[response_index++] = dbfilename;
+      } else {
+        add_error_reply(ch->client, "ERR Unknown config parameter");
+        return;
+      }
+    }
+    add_array_reply(ch->client, response, response_index);
+  }
 }

--- a/src/commands.h
+++ b/src/commands.h
@@ -24,7 +24,8 @@ void handle_lpush(CommandHandler *ch);
 void handle_rpush(CommandHandler *ch);
 void handle_lrange(CommandHandler *ch);
 void handle_config(CommandHandler *ch);
-
+void handle_save(CommandHandler *ch);
+void handle_dbsize(CommandHandler *ch);
 void add_error_reply(Client *client, const char *str);
 
 #endif // COMMAND_H

--- a/src/commands.h
+++ b/src/commands.h
@@ -23,6 +23,7 @@ void handle_decr(CommandHandler *ch);
 void handle_lpush(CommandHandler *ch);
 void handle_rpush(CommandHandler *ch);
 void handle_lrange(CommandHandler *ch);
+void handle_config(CommandHandler *ch);
 
 void add_error_reply(Client *client, const char *str);
 

--- a/src/database.h
+++ b/src/database.h
@@ -18,14 +18,24 @@ typedef struct {
 
 KHASH_MAP_INIT_STR(redis_hash, RedisValue *)
 
-void redis_db_create();
-void redis_db_destroy();
-void redis_db_set(const char *key, const void *value, ValueType type, long long expiration);
-RedisValue *redis_db_get(const char *key);
-bool redis_db_exist(const char *key);
-void redis_db_delete(const char *key);
-int redis_db_lpush(const char *key, const char *item, int *length);
-int redis_db_rpush(const char *key, const char *item, int *length);
-int redis_db_lrange(const char *key, int start, int end, char ***range, int *range_length);
+typedef struct redis_db {
+  khash_t(redis_hash) * h;
+  size_t key_count;
+  size_t expiry_count;
+} redis_db_t;
 
+redis_db_t *redis_db_create();
+void redis_db_destroy(redis_db_t *db);
+void redis_db_set(redis_db_t *db, const char *key, const void *value, ValueType type,
+                  long long expiration);
+RedisValue *redis_db_get(redis_db_t *db, const char *key);
+bool redis_db_exist(redis_db_t *db, const char *key);
+void redis_db_delete(redis_db_t *db, const char *key);
+int redis_db_lpush(redis_db_t *db, const char *key, const char *item, int *length);
+int redis_db_rpush(redis_db_t *db, const char *key, const char *item, int *length);
+int redis_db_lrange(redis_db_t *db, const char *key, int start, int end, char ***range,
+                    int *range_length);
+bool redis_db_save(redis_db_t *db);
+size_t redis_db_dbsize(redis_db_t *db);
+size_t redis_db_expiry_count(redis_db_t *db);
 #endif // DATABASE_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 #include "redis-server.h"
 
-int main() {
-  int status = start_server();
+int main(int argc, char **argv) {
+  int status = start_server(argc, argv);
   return status;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include "redis-server.h"
 
 int main(int argc, char **argv) {
+  printf("# redis_lite started\n");
   int status = start_server(argc, argv);
   return status;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1,0 +1,374 @@
+#include "rdb.h"
+#include "commands.h"
+#include "database.h"
+
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+char *read_rdb_string(FILE *file);
+int write_rdb_string(FILE *file, const char *str);
+char *construct_file_path(const char *dir, const char *filename);
+
+int rdb_load_data_from_file(redis_db_t *db, const char *dir, const char *filename) {
+  const char *path = construct_file_path(dir, filename);
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    perror("failed to open RDB file or it does not exist\n");
+    return -1;
+  }
+
+  // consume header section, magic string + version number (ASCII): REDIS0011
+  char buf[64];
+  if (fread(buf, 1, 9, file) != 9) {
+    perror("failed to read header\n");
+    fclose(file);
+    return 1;
+  }
+  buf[9] = '\0';
+
+  if (strcmp(buf, "REDIS0012") != 0) {
+    printf("header does not contain expected magic string + version number (0012)\n");
+    printf("expected: REDIS0012, got: %s\n", buf);
+    fclose(file);
+    return 1;
+  }
+
+  // main RDB section loop
+  int done = 0;
+  while (!done) {
+    int opcode = fgetc(file);
+    if (opcode == EOF) {
+      perror("unexpected end of file while reading RDB\n");
+      break;
+    }
+    switch (opcode) {
+    case 0xFA: // mwetadata section start
+      while (1) {
+        int next = fgetc(file);
+        if (next == 0xFE) {
+          // end of metadata section
+          break;
+        }
+        if (next == EOF) {
+          perror("unexpected end of file while reading metadata section\n");
+          fclose(file);
+          return 1;
+        }
+        ungetc(next, file); // put back for string read
+        char *key = read_rdb_string(file);
+        if (!key) break;
+        char *value = read_rdb_string(file);
+        if (!value) {
+          free(key);
+          break;
+        }
+        free(key);
+        free(value);
+      }
+      break;
+    case 0xFB: { // hash table size info
+      int kv_size;
+      int exp_size;
+      int i;
+      int type;
+      uint64_t expire_time;
+
+      kv_size = fgetc(file);  // number of key-value pairs in the hash table
+      exp_size = fgetc(file); // number of keys with expiry
+      if (kv_size == EOF || exp_size == EOF) {
+        perror("unexpected end of file while reading hash table size info\n");
+        fclose(file);
+        return 1;
+      }
+      // read the key-value pairs
+      for (i = 0; i < kv_size; i++) {
+        type = fgetc(file); // read type/encoding opcode
+        expire_time = 0;
+
+        if (type == EOF) {
+          perror("unexpected end of file while reading key-value pairs\n");
+          fclose(file);
+          return 1;
+        }
+
+        // check for expiration
+        if (type == 0xFD) { // expire time in seconds
+          uint32_t seconds;
+          if (fread(&seconds, 4, 1, file) != 1) {
+            perror("failed to read expiration time from RDB file\n");
+            fclose(file);
+            return 1;
+          }
+          expire_time = seconds * 1000; // convert seconds to milliseconds
+          type = fgetc(file);           // read the next type byte
+        } else if (type == 0xFC) {      // expire time in milliseconds
+          uint64_t milliseconds;
+          if (fread(&milliseconds, 8, 1, file) != 1) {
+            perror("failed to read expiration time from RDB file\n");
+            fclose(file);
+            return 1;
+          }
+          expire_time = milliseconds; // already in milliseconds
+          type = fgetc(file);         // read the next type byte
+        }
+
+        if (type == 0x00) { // string
+          // read the key-value pair as a string
+          char *key = read_rdb_string(file);
+          if (!key) {
+            perror("failed to read key from RDB file\n");
+            fclose(file);
+            return 1;
+          }
+          char *value = read_rdb_string(file);
+          if (!value) {
+            free(key);
+            perror("failed to read value from RDB file\n");
+            fclose(file);
+            return 1;
+          }
+
+          // Debug print to verify key and value
+          // printf("RDB LOAD: key='%s', value='%s', expire_time=%llu\n", key, value, (unsigned long long)expire_time);
+
+          // insert in DB
+          redis_db_set(db, key, value, TYPE_STRING, expire_time);
+
+          free(key);
+          free(value);
+        } else {
+          printf("Unhandled type: 0x%02X\n", type);
+        }
+      }
+      break;
+    }
+    case 0xFE:
+      // database index
+      printf("database selector (0xFE) encountered.\n");
+      // No support for multiple databases yet, so we just read the index.
+      int db_index = fgetc(file);
+      if (db_index == EOF) {
+        perror("unexpected end of file while reading database index\n");
+        fclose(file);
+        return 1;
+      }
+    case 0xFF: // end of RDB file
+      done = 1;
+      break;
+    default:
+      break;
+    }
+  }
+
+  fclose(file);
+  return 0;
+}
+
+char *read_rdb_string(FILE *file) {
+  int first = fgetc(file);
+  if (first == EOF) return NULL;
+  unsigned char first_byte = (unsigned char)first;
+
+  int type = first_byte >> 6;
+  int len = 0;
+
+  if (type == 0b00) {
+    // remaining 6 bits is length
+    len = first_byte & 0x3F;
+  } else if (type == 0b01) {
+    // next 14 bits is length
+    len = (first_byte & 0x3F) << 8;
+    int second = fgetc(file);
+    if (second == EOF) return NULL;
+    len |= second; // combine with the next byte
+  } else if (type == 0b10) {
+    // next 4 bytes is length in big-endian
+    len = 0;
+    for (int i = 0; i < 4; i++) {
+      char byte = fgetc(file);
+      if (byte == EOF) return NULL;
+      len = (len << 8) | (unsigned char)byte; // shift left and add the next byte
+    }
+  } else if (type == 0b11) {
+    // this is a string encoded value
+    int enc_type = first_byte & 0x3F;
+    char buf[32];
+    if (enc_type == 0) {
+      // 8-bit integer as string
+      int val = fgetc(file);
+      if (val == EOF) return NULL;
+      snprintf(buf, sizeof(buf), "%d", (int8_t)val);
+      return strdup(buf);
+    } else if (enc_type == 1) {
+      // 16-bit integer as string (little-endian)
+      int lo = fgetc(file);
+      int hi = fgetc(file);
+      if (lo == EOF || hi == EOF) return NULL;
+      int16_t val = (hi << 8) | lo;
+      snprintf(buf, sizeof(buf), "%d", val);
+      return strdup(buf);
+    } else if (enc_type == 2) {
+      // 32-bit integer as string (little-endian)
+      uint32_t val = 0;
+      for (int i = 0; i < 4; ++i) {
+        int b = fgetc(file);
+        if (b == EOF) return NULL;
+        val |= ((uint32_t)b) << (8 * i);
+      }
+      snprintf(buf, sizeof(buf), "%d", (int32_t)val);
+      return strdup(buf);
+    } else if (enc_type == 3) {
+      // LZF-compressed string (not implemented)
+      printf("LZF-compressed string not supported.\n");
+      return NULL;
+    } else {
+      return NULL;
+    }
+  }
+  char *str = malloc(len + 1);
+  if (!str) {
+    perror("failed to allocate memory for string\n");
+    return NULL;
+  }
+
+  if (fread(str, 1, len, file) != len) {
+    perror("failed to read string from file\n");
+    free(str);
+    return NULL;
+  }
+
+  str[len] = '\0';
+  return str;
+}
+
+int write_rdb_string(FILE *file, const char *str) {
+  int len = strlen(str);
+  char *endptr;
+  long long value = strtoll(str, &endptr, 10);
+  if (*endptr == '\0') { // string is a valid integer
+    if (value >= INT8_MIN && value <= INT8_MAX) {
+      // 8-bit integer encoding: 1 byte header + 1 byte value = 2 bytes (16 bits)
+      uint8_t header = 0xC0;
+      fputc(header, file);
+      fputc((int8_t)value, file);
+      return 2;
+    } else if (value >= INT16_MIN && value <= INT16_MAX) {
+      // 16-bit integer encoding: 1 byte header + 2 bytes value = 3 bytes (24 bits)
+      uint8_t header = 0xC1;
+      fputc(header, file);
+      int16_t v = (int16_t)value;
+      fputc(v & 0xFF, file);
+      fputc((v >> 8) & 0xFF, file);
+      return 3;
+    } else if (value >= INT32_MIN && value <= INT32_MAX) {
+      // 32-bit integer encoding: 1 byte header + 4 bytes value = 5 bytes (40 bits)
+      uint8_t header = 0xC2;
+      fputc(header, file);
+      int32_t v = (int32_t)value;
+      for (int i = 0; i < 4; i++) {
+        fputc((v >> (8 * i)) & 0xFF, file);
+      }
+      return 5;
+    }
+  }
+
+  if (len <= 63) {
+    // 1-byte header + len bytes data = len+1 bytes = (len+1)*8 bits
+    uint8_t header = (0b00 << 6) | len;
+    fputc(header, file);
+    fwrite(str, 1, len, file);
+    return 1 + len;
+  } else if (len <= 16383) {
+    // 2-byte header + len bytes data = len+2 bytes = (len+2)*8 bits
+    uint16_t header = (0b01 << 14) | len;
+    fputc((header >> 8) & 0xFF, file);
+    fputc(header & 0xFF, file);
+    fwrite(str, 1, len, file);
+    return 2 + len;
+  } else {
+    // 1-byte header + 4-byte length + len bytes data = len+5 bytes = (len+5)*8 bits
+    uint8_t header = (0b10 << 6);
+    fputc(header, file);
+    uint32_t ulen = (uint32_t)len;
+    for (int i = 3; i >= 0; i--) {
+      fputc((ulen >> (8 * i)) & 0xFF, file);
+    }
+    fwrite(str, 1, len, file);
+    return 5 + len;
+  }
+}
+
+bool rdb_save_data_to_file(redis_db_t *db, const char *dir, const char *filename) {
+  const char *path = construct_file_path(dir, filename);
+
+  // create directory
+  if (mkdir(dir, 0755) != 0 && errno != EEXIST) {
+    perror("failed to create directory for RDB file");
+    return false;
+  }
+  FILE *file = fopen(path, "wb");
+  if (!file) {
+    perror("could not open rdb file");
+  }
+  // write header:
+  fwrite("REDIS0012", 1, 9, file);
+  // write metadata section
+  fputc(0xFA, file); // start metadata section
+  // for each metadata key/value pair:
+  // write_rdb_String(file, "meta_key");
+  // write_rdb_string(file, "meta_value");
+  fputc(0xFE, file); // end metadata section
+
+  // write 0xFB, kv_size, exp-size
+  fputc(0xFB, file); // hash table size information
+  fputc(db->key_count, file);
+  fputc(db->expiry_count, file); // for now I can count all the keys with an expiry
+
+  // for each key:
+  // -if has expiry, write 0xFD/0xFC and expiry time
+  //  write type
+  //  write_rdb_string(key)
+  //  write_rdb_string(value)
+  khash_t(redis_hash) *h = db->h;
+  for (khiter_t k = kh_begin(h); k != kh_end(h); k++) {
+    if (!kh_exist(h, k)) continue;
+    const char *key = kh_key(h, k);
+    RedisValue *val = kh_value(h, k);
+    // write expiry if it has
+    if (val->expiration > 0) {
+      fputc(0xFC, file); // type for ms expiry, since we store all expiry in ms
+      uint64_t ms = (uint64_t)val->expiration;
+      // Write 8 bytes in little-endian order
+      for (int i = 0; i < 8; i++) {
+        fputc((ms >> (8 * i)) & 0xFF, file);
+      }
+    }
+    // persist string values (write_rdb_string will handle integer encoding if possible)
+    if (val->type == TYPE_STRING) {
+      fputc(0x00, file); // type for string
+      write_rdb_string(file, key);
+      write_rdb_string(file, val->data.str);
+    } else {
+      // TODO persist other value types
+    }
+  }
+
+  // write 0xFF
+  fputc(0xFF, file);
+  // close file
+  fclose(file);
+}
+
+char *construct_file_path(const char *dir, const char *filename) {
+  size_t path_len = strlen(dir) + strlen(filename) + 2; // +1 for '/' or '\0', +1 for '\0'
+  char *path = malloc(path_len);
+  if (!path) return NULL;
+  if (dir[strlen(dir) - 1] == '/') {
+    snprintf(path, path_len, "%s%s", dir, filename);
+  } else {
+    snprintf(path, path_len, "%s/%s", dir, filename);
+  }
+  return path;
+}

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -1,0 +1,9 @@
+#ifndef RDB_H
+#define RDB_H
+
+#include "database.h"
+
+int rdb_load_data_from_file(redis_db_t *db, const char *dir, const char *filename);
+bool rdb_save_data_to_file(redis_db_t *db, const char *dir, const char *filename);
+
+#endif // RDB_H

--- a/src/redis-server.c
+++ b/src/redis-server.c
@@ -20,7 +20,7 @@
 #define MAX_EVENTS 10000
 
 #define MAX_PATH_LENGTH 256
-char dir[MAX_PATH_LENGTH] = "/tmp";            // default directory for rdb persistence file
+char dir[MAX_PATH_LENGTH] = "/tmp/redis-data"; // default directory for rdb persistence file
 char dbfilename[MAX_PATH_LENGTH] = "dump.rdb"; // default name for rdb persistence file
 
 void process_client_input(Client *client, int epfd) {

--- a/src/redis-server.c
+++ b/src/redis-server.c
@@ -19,6 +19,10 @@
 #define DEFAULT_PORT 6379
 #define MAX_EVENTS 10000
 
+#define MAX_PATH_LENGTH 256
+char dir[MAX_PATH_LENGTH] = "/tmp";            // default directory for rdb persistence file
+char dbfilename[MAX_PATH_LENGTH] = "dump.rdb"; // default name for rdb persistence file
+
 void process_client_input(Client *client, int epfd) {
   for (;;) {
 
@@ -97,7 +101,19 @@ volatile sig_atomic_t stop_server = 0;
 
 void sigint_handler(int sig) { stop_server = 1; }
 
-int start_server() {
+int start_server(int argc, char *argv[]) {
+
+  // parse command-line args
+  for (int i = 1; i < argc; i++) {
+    if (i + 1 < argc) {
+      if (strcmp(argv[i], "--dir") == 0) {
+        snprintf(dir, MAX_PATH_LENGTH, "%s", argv[i + 1]);
+      } else if (strcmp(argv[i], "--dbfilename") == 0) {
+        snprintf(dbfilename, MAX_PATH_LENGTH, "%s", argv[i + 1]);
+      }
+    }
+  }
+
   // register the signal handler
   signal(SIGINT, sigint_handler);
 

--- a/src/server_config.h
+++ b/src/server_config.h
@@ -1,0 +1,11 @@
+#ifndef SERVER_CONFIG_H
+#define SERVER_CONFIG_H
+
+typedef struct server_config {
+  char dir[256];
+  char dbfilename[256];
+} server_config_t;
+
+extern server_config_t g_server_config;
+
+#endif // SERVER_CONFIG_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,8 @@ set(COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/commands.c
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/linked_list.c
+    ${CMAKE_SOURCE_DIR}/src/redis-server.c
+
 )
 
 set(TEST_EXECUTABLES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ set(COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/linked_list.c
     ${CMAKE_SOURCE_DIR}/src/redis-server.c
-
+    ${CMAKE_SOURCE_DIR}/src/rdb.c
 )
 
 set(TEST_EXECUTABLES

--- a/test/command_test.cc
+++ b/test/command_test.cc
@@ -4,7 +4,11 @@ extern "C" {
 #include "command_handler.h"
 #include "commands.h"
 #include "database.h"
+
+extern char dir[256];
+extern char dbfilename[256];
 }
+
 
 class CommandTest : public ::testing::Test {
 protected:
@@ -345,3 +349,11 @@ TEST_F(CommandTest, LrangeKeyNotFound) {
 
   EXPECT_EQ(GetReply(), "*0\r\n");
 }
+
+TEST_F(CommandTest, GetConfig) {
+  ExecuteCommand({"CONFIG", "GET", "dir"});
+  EXPECT_EQ(GetReply(), "*2\r\n$3\r\ndir\r\n$" + std::to_string(strlen(dir)) + "\r\n" + std::string(dir) + "\r\n");
+
+  ExecuteCommand({"CONFIG", "GET", "dbfilename"});
+  EXPECT_EQ(GetReply(), "*2\r\n$10\r\ndbfilename\r\n$" + std::to_string(strlen(dbfilename)) + "\r\n" + std::string(dbfilename) + "\r\n");
+} 

--- a/test/dictionary_test.cc
+++ b/test/dictionary_test.cc
@@ -1,25 +1,29 @@
 extern "C" {
-#include "database.h"
-#include "util.h"
+#include "../src/database.h"
+#include "../src/util.h"
 }
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+redis_db_t *db;
+
 class DatabaseTest : public ::testing::Test {
 protected:
-  void SetUp() override { redis_db_create(); }
-  void TearDown() override { redis_db_destroy(); }
+  void SetUp() override { db = redis_db_create(); }
+  void TearDown() override { redis_db_destroy(db); }
 };
 
 TEST_F(DatabaseTest, SetValueString) {
   const char *key = "test_key";
   const char *value = "test_value";
-  redis_db_set(key, value, TYPE_STRING, 0);
+  redis_db_set(db, key, value, TYPE_STRING, 0);
 
-  RedisValue *rv = redis_db_get(key);
+  RedisValue *rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_STRING);
   EXPECT_STREQ(rv->data.str, value);
+  EXPECT_EQ(db->key_count, 1);
+  EXPECT_EQ(db->expiry_count, 0);
 }
 
 TEST_F(DatabaseTest, OverwriteExistingStringValue) {
@@ -27,33 +31,36 @@ TEST_F(DatabaseTest, OverwriteExistingStringValue) {
   const char *initial_value = "initial_value";
   const char *new_value = "new_value";
 
-  redis_db_set(key, initial_value, TYPE_STRING, 0);
+  redis_db_set(db, key, initial_value, TYPE_STRING, 0);
 
-  RedisValue *rv = redis_db_get(key);
+  RedisValue *rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_STRING);
   EXPECT_STREQ(rv->data.str, initial_value);
+  EXPECT_EQ(db->key_count, 1);
 
-  redis_db_set(key, new_value, TYPE_STRING, 0);
-  rv = redis_db_get(key);
+  redis_db_set(db, key, new_value, TYPE_STRING, 0);
+  rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_STRING);
   EXPECT_STREQ(rv->data.str, new_value);
+  EXPECT_EQ(db->key_count, 1);
+  EXPECT_EQ(db->expiry_count, 0);
 }
 
 TEST_F(DatabaseTest, GetValueString) {
   const char *key = "test_key";
   const char *value = "test_value";
-  redis_db_set(key, value, TYPE_STRING, 0);
+  redis_db_set(db, key, value, TYPE_STRING, 0);
 
-  RedisValue *retrieved_value = redis_db_get(key);
+  RedisValue *retrieved_value = redis_db_get(db, key);
   ASSERT_NE(retrieved_value, nullptr);
   EXPECT_EQ(retrieved_value->type, TYPE_STRING);
   EXPECT_STREQ(retrieved_value->data.str, value);
 }
 
 TEST_F(DatabaseTest, GetValueKeyNotFound) {
-  RedisValue *retrieved_value = redis_db_get("non_existent_key");
+  RedisValue *retrieved_value = redis_db_get(db, "non_existent_key");
   ASSERT_EQ(retrieved_value, nullptr);
 }
 
@@ -61,35 +68,39 @@ TEST_F(DatabaseTest, SetValueWithExpiration) {
   const char *key = "expiring_key";
   const char *value = "expiring_value";
   long long expiration = current_time_millis() + 1000; // 1 second from now
-  redis_db_set(key, value, TYPE_STRING, expiration);
+  redis_db_set(db, key, value, TYPE_STRING, expiration);
 
-  RedisValue *retrieved_value = redis_db_get(key);
+  RedisValue *retrieved_value = redis_db_get(db, key);
   ASSERT_NE(retrieved_value, nullptr);
   EXPECT_EQ(retrieved_value->type, TYPE_STRING);
   EXPECT_STREQ(retrieved_value->data.str, value);
   EXPECT_EQ(retrieved_value->expiration, expiration);
+  EXPECT_EQ(db->key_count, 1);
+  EXPECT_EQ(db->expiry_count, 1);
 }
 
 TEST_F(DatabaseTest, GetExpiredValue) {
   const char *key = "expired_key";
   const char *value = "expired_value";
   long long expiration = current_time_millis() - 1000; // 1 second ago
-  redis_db_set(key, value, TYPE_STRING, expiration);
+  redis_db_set(db, key, value, TYPE_STRING, expiration);
 
-  RedisValue *retrieved_value = redis_db_get(key);
+  RedisValue *retrieved_value = redis_db_get(db, key);
   ASSERT_EQ(retrieved_value, nullptr);
+  EXPECT_EQ(db->key_count, 0);
+  EXPECT_EQ(db->expiry_count, 0);
 }
 
 TEST_F(DatabaseTest, UpdateExpirationTime) {
   const char *key = "update_expiry_key";
   const char *value = "update_expiry_value";
   long long initial_expiration = current_time_millis() + 1000; // 1 second from now
-  redis_db_set(key, value, TYPE_STRING, initial_expiration);
+  redis_db_set(db, key, value, TYPE_STRING, initial_expiration);
 
   long long new_expiration = current_time_millis() + 5000; // 5 seconds from now
-  redis_db_set(key, value, TYPE_STRING, new_expiration);
+  redis_db_set(db, key, value, TYPE_STRING, new_expiration);
 
-  RedisValue *retrieved_value = redis_db_get(key);
+  RedisValue *retrieved_value = redis_db_get(db, key);
   ASSERT_NE(retrieved_value, nullptr);
   EXPECT_EQ(retrieved_value->expiration, new_expiration);
 }
@@ -98,12 +109,12 @@ TEST_F(DatabaseTest, RemoveExpirationAndPersist) {
   const char *key = "remove_expiry_key";
   const char *value = "remove_expiry_value";
   long long initial_expiration = current_time_millis() + 1000; // 1 second from now
-  redis_db_set(key, value, TYPE_STRING, initial_expiration);
+  redis_db_set(db, key, value, TYPE_STRING, initial_expiration);
 
-  redis_db_set(key, value, TYPE_STRING, 0); // set without expiration
+  redis_db_set(db, key, value, TYPE_STRING, 0); // set without expiration
   usleep(1100000); // sleep for 1.1 seconds, to verify if key persists after removing expiration
 
-  RedisValue *retrieved_value = redis_db_get(key);
+  RedisValue *retrieved_value = redis_db_get(db, key);
   ASSERT_NE(retrieved_value, nullptr);
   EXPECT_EQ(retrieved_value->expiration, 0);
 }
@@ -115,28 +126,28 @@ TEST_F(DatabaseTest, MultipleKeysWithExpiration) {
   const char *value = "value";
 
   long long now = current_time_millis();
-  redis_db_set(key1, value, TYPE_STRING, now - 1000); // already expired
-  redis_db_set(key2, value, TYPE_STRING, now + 1000); // expires in 1 second
-  redis_db_set(key3, value, TYPE_STRING, 0);          // no expiration
+  redis_db_set(db, key1, value, TYPE_STRING, now - 1000); // already expired
+  redis_db_set(db, key2, value, TYPE_STRING, now + 1000); // expires in 1 second
+  redis_db_set(db, key3, value, TYPE_STRING, 0);          // no expiration
 
-  EXPECT_EQ(redis_db_get(key1), nullptr);
-  EXPECT_NE(redis_db_get(key2), nullptr);
-  EXPECT_NE(redis_db_get(key3), nullptr);
+  EXPECT_EQ(redis_db_get(db, key1), nullptr);
+  EXPECT_NE(redis_db_get(db, key2), nullptr);
+  EXPECT_NE(redis_db_get(db, key3), nullptr);
 
   // wait for key2 to expire
   usleep(1100000); // sleep for 1.1 seconds
 
-  EXPECT_EQ(redis_db_get(key1), nullptr);
-  EXPECT_EQ(redis_db_get(key2), nullptr);
-  EXPECT_NE(redis_db_get(key3), nullptr);
+  EXPECT_EQ(redis_db_get(db, key1), nullptr);
+  EXPECT_EQ(redis_db_get(db, key2), nullptr);
+  EXPECT_NE(redis_db_get(db, key3), nullptr);
 }
 
 TEST_F(DatabaseTest, SetAndCheckExists) {
   const char *key = "test_key";
   const char *value = "test_value";
-  redis_db_set(key, value, TYPE_STRING, 0);
+  redis_db_set(db, key, value, TYPE_STRING, 0);
 
-  bool exists = redis_db_exist(key);
+  bool exists = redis_db_exist(db, key);
 
   EXPECT_EQ(exists, true);
 }
@@ -144,7 +155,7 @@ TEST_F(DatabaseTest, SetAndCheckExists) {
 TEST_F(DatabaseTest, DoNotSetKeyShouldNotExist) {
   const char *key = "test_key";
 
-  bool exists = redis_db_exist(key);
+  bool exists = redis_db_exist(db, key);
 
   EXPECT_EQ(exists, false);
 }
@@ -152,10 +163,10 @@ TEST_F(DatabaseTest, DoNotSetKeyShouldNotExist) {
 TEST_F(DatabaseTest, DeleteShouldNotExist) {
   const char *key = "test_key";
   const char *value = "test_value";
-  redis_db_set(key, value, TYPE_STRING, 0);
-  redis_db_delete(key);
+  redis_db_set(db, key, value, TYPE_STRING, 0);
+  redis_db_delete(db, key);
 
-  bool exists = redis_db_exist(key);
+  bool exists = redis_db_exist(db, key);
 
   EXPECT_EQ(exists, false);
 }
@@ -166,13 +177,13 @@ TEST_F(DatabaseTest, LPushOperation) {
   const char *value2 = "value2";
   int length;
 
-  EXPECT_EQ(redis_db_lpush(key, value1, &length), 0);
+  EXPECT_EQ(redis_db_lpush(db, key, value1, &length), 0);
   EXPECT_EQ(length, 1);
 
-  EXPECT_EQ(redis_db_lpush(key, value2, &length), 0);
+  EXPECT_EQ(redis_db_lpush(db, key, value2, &length), 0);
   EXPECT_EQ(length, 2);
 
-  RedisValue *rv = redis_db_get(key);
+  RedisValue *rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_LIST);
   EXPECT_EQ(get_list_length(rv->data.list), 2);
@@ -184,13 +195,13 @@ TEST_F(DatabaseTest, RPushOperation) {
   const char *value2 = "value2";
   int length;
 
-  EXPECT_EQ(redis_db_rpush(key, value1, &length), 0);
+  EXPECT_EQ(redis_db_rpush(db, key, value1, &length), 0);
   EXPECT_EQ(length, 1);
 
-  EXPECT_EQ(redis_db_rpush(key, value2, &length), 0);
+  EXPECT_EQ(redis_db_rpush(db, key, value2, &length), 0);
   EXPECT_EQ(length, 2);
 
-  RedisValue *rv = redis_db_get(key);
+  RedisValue *rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_LIST);
   EXPECT_EQ(get_list_length(rv->data.list), 2);
@@ -202,11 +213,11 @@ TEST_F(DatabaseTest, LPushRPushCombined) {
   const char *value2 = "value2";
   int length;
 
-  EXPECT_EQ(redis_db_lpush(key, value1, &length), 0);
-  EXPECT_EQ(redis_db_rpush(key, value2, &length), 0);
+  EXPECT_EQ(redis_db_lpush(db, key, value1, &length), 0);
+  EXPECT_EQ(redis_db_rpush(db, key, value2, &length), 0);
   EXPECT_EQ(length, 2);
 
-  RedisValue *rv = redis_db_get(key);
+  RedisValue *rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_LIST);
   EXPECT_EQ(get_list_length(rv->data.list), 2);
@@ -218,12 +229,12 @@ TEST_F(DatabaseTest, PushToNonListKey) {
   const char *list_value = "list_value";
   int length;
 
-  redis_db_set(key, string_value, TYPE_STRING, 0);
+  redis_db_set(db, key, string_value, TYPE_STRING, 0);
 
-  EXPECT_EQ(redis_db_lpush(key, list_value, &length), ERR_TYPE_MISMATCH);
-  EXPECT_EQ(redis_db_rpush(key, list_value, &length), ERR_TYPE_MISMATCH);
+  EXPECT_EQ(redis_db_lpush(db, key, list_value, &length), ERR_TYPE_MISMATCH);
+  EXPECT_EQ(redis_db_rpush(db, key, list_value, &length), ERR_TYPE_MISMATCH);
 
-  RedisValue *rv = redis_db_get(key);
+  RedisValue *rv = redis_db_get(db, key);
   ASSERT_NE(rv, nullptr);
   EXPECT_EQ(rv->type, TYPE_STRING);
   EXPECT_STREQ(rv->data.str, string_value);
@@ -234,12 +245,12 @@ TEST_F(DatabaseTest, DeleteList) {
   const char *value = "value";
   int length;
 
-  EXPECT_EQ(redis_db_lpush(key, value, &length), 0);
+  EXPECT_EQ(redis_db_lpush(db, key, value, &length), 0);
   EXPECT_EQ(length, 1);
 
-  redis_db_delete(key);
+  redis_db_delete(db, key);
 
-  EXPECT_FALSE(redis_db_exist(key));
+  EXPECT_FALSE(redis_db_exist(db, key));
 }
 
 TEST_F(DatabaseTest, LrangeValidRange) {
@@ -249,14 +260,14 @@ TEST_F(DatabaseTest, LrangeValidRange) {
   const char *value3 = "value3";
   int length;
 
-  EXPECT_EQ(redis_db_rpush(key, value1, &length), 0);
-  EXPECT_EQ(redis_db_rpush(key, value2, &length), 0);
-  EXPECT_EQ(redis_db_rpush(key, value3, &length), 0);
+  EXPECT_EQ(redis_db_rpush(db, key, value1, &length), 0);
+  EXPECT_EQ(redis_db_rpush(db, key, value2, &length), 0);
+  EXPECT_EQ(redis_db_rpush(db, key, value3, &length), 0);
   EXPECT_EQ(length, 3);
 
   char **range;
   int range_length;
-  int result = redis_db_lrange(key, 0, 2, &range, &range_length);
+  int result = redis_db_lrange(db, key, 0, 2, &range, &range_length);
   EXPECT_EQ(result, 0); // check for success
   EXPECT_NE(range, nullptr);
   EXPECT_EQ(range[0], std::string(value1));
@@ -266,7 +277,7 @@ TEST_F(DatabaseTest, LrangeValidRange) {
   cleanup_lrange_result(range, range_length);
 
   // test partial range
-  result = redis_db_lrange(key, 0, 1, &range, &range_length);
+  result = redis_db_lrange(db, key, 0, 1, &range, &range_length);
   EXPECT_EQ(result, 0); // check for success
   EXPECT_NE(range, nullptr);
   EXPECT_EQ(range[0], std::string(value1));
@@ -275,7 +286,7 @@ TEST_F(DatabaseTest, LrangeValidRange) {
   cleanup_lrange_result(range, range_length);
 
   // test range end out of bounds
-  result = redis_db_lrange(key, 0, 5, &range, &range_length);
+  result = redis_db_lrange(db, key, 0, 5, &range, &range_length);
   EXPECT_EQ(result, 0); // check for success
   EXPECT_NE(range, nullptr);
   EXPECT_EQ(range[0], std::string(value1));
@@ -285,7 +296,7 @@ TEST_F(DatabaseTest, LrangeValidRange) {
   cleanup_lrange_result(range, range_length);
 
   // test range negative indices
-  result = redis_db_lrange(key, -3, -1, &range, &range_length);
+  result = redis_db_lrange(db, key, -3, -1, &range, &range_length);
   EXPECT_EQ(result, 0); // check for success
   EXPECT_NE(range, nullptr);
   EXPECT_EQ(range[0], std::string(value1));
@@ -294,7 +305,7 @@ TEST_F(DatabaseTest, LrangeValidRange) {
 
   cleanup_lrange_result(range, range_length); // Clean up again
 
-  redis_db_delete(key); // delete the list
-  result = redis_db_lrange(key, 0, 2, &range, &range_length);
+  redis_db_delete(db, key); // delete the list
+  result = redis_db_lrange(db, key, 0, 2, &range, &range_length);
   EXPECT_EQ(result, ERR_KEY_NOT_FOUND); // Expect an error for non-existent key
 }


### PR DESCRIPTION
Implemented the ability to persist the database to disk using the SAVE command and load from disk on startup.

SAVE synchronously persists the database to disk, meaning clients cannot be served while the snapshot is in process. Currently only value types that are stored as strings can be persisted, future types may be supported (lists are not supported yet).

Other small improvements include:
- Implement a DBSIZE command to get the number of keys in the database
- Encapsulate database info for modularity and future multi-database support
- Add informative messages on startup and shutdown
- Persist to disk on graceful shutdown when (EINTR is detected) 

 Future improvements would include implementing background save to enable snapshotting while serving clients using a BGSAVE command, while supporting persisting other value types.