### PR TITLE
Add INFO command support

### DIFF
--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -36,6 +36,8 @@ CommandType get_command_type(char *command) {
     return CMD_SAVE;
   else if (strcmp(command, "DBSIZE") == 0)
     return CMD_DBSIZE;
+  else if (strcmp(command, "INFO" == 0))
+    return CMD_INFO;
   else
     return CMD_UNKNOWN;
 }
@@ -86,6 +88,9 @@ void handle_command(CommandHandler *ch) {
     break;
   case CMD_DBSIZE:
     handle_dbsize(ch);
+    break;
+  case CMD_INFO:
+    handle_info(ch);
     break;
   default:
     add_error_reply(ch->client, "ERR unknown command");

--- a/src/command_handler.c
+++ b/src/command_handler.c
@@ -32,10 +32,9 @@ CommandType get_command_type(char *command) {
     return CMD_LRANGE;
   else if (strcmp(command, "CONFIG") == 0)
     return CMD_CONFIG;
-  else if (strcmp(command, "SAVE") == 0) {
-    printf("RECEIVED COMMAND SAVE\n");
+  else if (strcmp(command, "SAVE") == 0)
     return CMD_SAVE;
-  } else if (strcmp(command, "DBSIZE") == 0)
+  else if (strcmp(command, "DBSIZE") == 0)
     return CMD_DBSIZE;
   else
     return CMD_UNKNOWN;

--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -24,7 +24,8 @@ typedef enum {
   CMD_CONFIG,
   CMD_SAVE,
   CMD_DBSIZE,
-  CMD_UNKNOWN
+  CMD_INFO,
+  CMD_UNKNOWN,
 } CommandType;
 
 typedef struct CommandHandler {

--- a/src/commands.c
+++ b/src/commands.c
@@ -389,3 +389,8 @@ void handle_dbsize(CommandHandler *ch) {
 
   add_integer_reply(ch->client, size);
 }
+
+void handle_info(CommandHandler *ch) {
+  // only support the "role" key for now
+  add_bulk_string_reply(ch->client, "role:master");
+}

--- a/src/commands.h
+++ b/src/commands.h
@@ -26,6 +26,7 @@ void handle_lrange(CommandHandler *ch);
 void handle_config(CommandHandler *ch);
 void handle_save(CommandHandler *ch);
 void handle_dbsize(CommandHandler *ch);
+void handle_info(CommandHandler *ch);
 void add_error_reply(Client *client, const char *str);
 
 #endif // COMMAND_H


### PR DESCRIPTION
For now, the INFO command only supports returning "role:master", future PR's will add the structures to store real replication info.