### PR TITLE
feat(replication): Add INFO command support for replica role

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -392,5 +392,7 @@ void handle_dbsize(CommandHandler *ch) {
 
 void handle_info(CommandHandler *ch) {
   // only support the "role" key for now
-  add_bulk_string_reply(ch->client, "role:master\r\n");
+  char role_info[32];
+  snprintf(role_info, sizeof(role_info), "role: %s\r\n", g_server_info.role);
+  add_bulk_string_reply(ch->client, role_info);
 }

--- a/src/server_config.h
+++ b/src/server_config.h
@@ -6,6 +6,11 @@ typedef struct server_config {
   char dbfilename[256];
 } server_config_t;
 
+typedef struct server_info {
+  char role[16];
+} server_info_t;
+
 extern server_config_t g_server_config;
+extern server_info_t g_server_info;
 
 #endif // SERVER_CONFIG_H


### PR DESCRIPTION
This PR introduces initial support for the INFO command to correctly report the server's role as a "slave" when the --replicaof flag is supplied during startup.

<img width="216" height="22" alt="Screenshot_258" src="https://github.com/user-attachments/assets/1d83ea38-5b07-4315-9f95-422fc41ee459" />

Refs #29