### PR TITLE
feat(replication): Add initial replication id and offset support to INFO command

### DIFF
--- a/src/redis-server.c
+++ b/src/redis-server.c
@@ -25,7 +25,10 @@
 
 server_config_t g_server_config = {.dir = "/tmp/redis-data", .dbfilename = "dump.rdb"};
 
-server_info_t g_server_info = {.role = "master"};
+server_info_t g_server_info = {.role = "master",
+                               .master_replid =
+                                   "0000000000000000000000000000000000000000", // hard code for now
+                               .master_repl_offset = 0};
 
 void process_client_input(Client *client, int epfd) {
   for (;;) {

--- a/src/server_config.h
+++ b/src/server_config.h
@@ -8,6 +8,8 @@ typedef struct server_config {
 
 typedef struct server_info {
   char role[16];
+  char master_replid[40];
+  long long master_repl_offset;
 } server_info_t;
 
 extern server_config_t g_server_config;


### PR DESCRIPTION
This PR introduces the necessary fields and initializations to track a server's replication ID and offset, and makes this information available through the INFO command. This lays essential groundwork for future replication logic.

<img width="534" height="112" alt="image" src="https://github.com/user-attachments/assets/91406e28-a56f-4a87-b245-94553fe0ab58" />

#29 