### PR TITLE
feat(replication): Implement master-replica handshake and RDB tr…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(redis_lite
     src/util.c
     src/database.c
     src/rdb.c
+    src/replication.c
 )
 
 # GoogleTest requires at least C++14

--- a/src/client.h
+++ b/src/client.h
@@ -5,8 +5,28 @@
 #include "handler.h"
 #include "resp.h"        // Include this for the Parser definition
 #include "ring_buffer.h" // Include this if ring_buffer is defined in a separate header
+#include <stdio.h>
 
 struct Parser;
+
+typedef enum { CLIENT_TYPE_REGULAR, CLIENT_TYPE_REPLICA, CLIENT_TYPE_MASTER } ClientType;
+
+typedef enum {
+  REPL_STATE_CONNECTING,
+  REPL_STATE_SENT_PING,
+  REPL_STATE_RECEIVED_PONG,
+  REPL_STATE_SENT_REPLCONF_PORT,
+  REPL_STATE_RECEIVED_REPLCONF_PORT_OK,
+  REPL_STATE_SENT_REPLCONF_CAPA,
+  REPL_STATE_RECEIVED_REPLCONF_CAPA_OK,
+  REPL_STATE_SENT_PSYNC,
+  REPL_STATE_RECEIVED_FULLRESYNC_RESPONSE,
+  REPL_STATE_RECEIVING_RDB_DATA,
+  REPL_STATE_READY,
+  REPL_STATE_ERROR
+} ReplicaClientState;
+
+typedef enum { MASTER_REPL_STATE_SENDING_RDB_DATA } MasterReplicaState;
 
 typedef struct Client {
   int fd;
@@ -14,11 +34,29 @@ typedef struct Client {
   ring_buffer output_buffer;
   struct Parser *parser;
   redis_db_t *db; // currently selected database
+  ClientType type;
+  int epoll_events; // epoll events that socket is being monitored for
+
+  /* replication specific fields */
+  // master specific fields
+  MasterReplicaState master_repl_state;
+  int rdb_fd; // pointer of rdb file being sent,
+  off_t rdb_file_offset;
+  off_t rdb_file_size;
+
+  // replica specific fields
+  ReplicaClientState repl_client_state;
+  long long rdb_expected_bytes;
+  long long rdb_received_bytes;
+  long long rdb_written_bytes;
+  FILE *tmp_rdb_fp; // temporary file for writing rdb from master
 } Client;
 
-Client *create_client(int fd, Handler *handler);
+Client *create_client(int fd);
 void select_client_db(Client *client, redis_db_t *db);
 void flush_client_output(Client *client);
 void destroy_client(Client *client);
+void process_client_input(Client *client);
+void handle_client_disconnection(Client *client);
 
 #endif // CLIENT_H

--- a/src/command_handler.h
+++ b/src/command_handler.h
@@ -26,6 +26,8 @@ typedef enum {
   CMD_DBSIZE,
   CMD_INFO,
   CMD_UNKNOWN,
+  CMD_REPLCONF,
+  CMD_PSYNC
 } CommandType;
 
 typedef struct CommandHandler {

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,61 +1,73 @@
 #include "commands.h"
+#include "client.h"
 #include "command_handler.h"
 #include "database.h"
 #include "linked_list.h"
+#include "redis-server.h"
 #include "server_config.h"
 #include "sys/time.h"
 #include "util.h"
 #include <errno.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 #define MAX_PATH_LENGTH 256
 #define INFO_BUFFER_SIZE 2048 // a buffer for various INFO fields
 
-void add_simple_string_reply(Client *client, const char *str) {
-  write_begin_simple_string(client->output_buffer);
-  write_chars(client->output_buffer, str);
-  write_end_simple_string(client->output_buffer);
+void add_simple_string_reply(ring_buffer rb, const char *str) {
+  write_begin_simple_string(rb);
+  write_chars(rb, str);
+  write_end_simple_string(rb);
 }
 
-void add_bulk_string_reply(Client *client, const char *str) {
+void add_bulk_string_reply(ring_buffer rb, const char *str) {
   int64_t len = strlen(str);
-  write_begin_bulk_string(client->output_buffer, len);
-  write_chars(client->output_buffer, str);
-  write_end_bulk_string(client->output_buffer);
+  write_begin_bulk_string(rb, len);
+  write_chars(rb, str);
+  write_end_bulk_string(rb);
 }
 
-void add_array_reply(Client *client, char **array, int length) {
-  write_begin_array(client->output_buffer, length);
+void add_array_reply(ring_buffer rb, char **array, int length) {
+  write_begin_array(rb, length);
   if (array != NULL) {
     for (int i = 0; i < length; i++) {
       int64_t len = strlen(array[i]);
-      write_begin_bulk_string(client->output_buffer, len);
-      write_chars(client->output_buffer, array[i]);
-      write_end_bulk_string(client->output_buffer);
+      write_begin_bulk_string(rb, len);
+      write_chars(rb, array[i]);
+      write_end_bulk_string(rb);
     }
   }
-  write_end_array(client->output_buffer);
+  write_end_array(rb);
 }
 
-void add_null_reply(Client *client) {
-  write_begin_bulk_string(client->output_buffer, -1); // indicate that this is a null bulk string
-  write_end_bulk_string(client->output_buffer);
+void add_null_reply(ring_buffer rb) {
+  write_begin_bulk_string(rb, -1); // indicate that this is a null bulk string
+  write_end_bulk_string(rb);
 }
 
-void add_error_reply(Client *client, const char *str) {
-  write_begin_error(client->output_buffer);
-  write_chars(client->output_buffer, str);
-  write_end_error(client->output_buffer);
+void add_error_reply(ring_buffer rb, const char *str) {
+  write_begin_error(rb);
+  write_chars(rb, str);
+  write_end_error(rb);
 }
 
-void add_integer_reply(Client *client, int integer) {
+void add_integer_reply(ring_buffer rb, int integer) {
   char number_str[32];
   snprintf(number_str, sizeof(number_str), "%d", integer);
 
-  write_begin_integer(client->output_buffer);
-  write_chars(client->output_buffer, number_str);
-  write_end_integer(client->output_buffer);
+  write_begin_integer(rb);
+  write_chars(rb, number_str);
+  write_end_integer(rb);
+}
+
+void add_psync_reply(ring_buffer rb, char *master_replid, long long master_repl_offset) {
+  printf("add_psync_reply called with master_replid: %s, master_repl_offset: %lld\n", master_replid,
+         master_repl_offset);
+  fflush(stdout);
+  char full_resync_reply[80];
+  snprintf(full_resync_reply, 80, "FULLRESYNC %s %lld", master_replid, master_repl_offset);
+  add_simple_string_reply(rb, full_resync_reply);
 }
 
 /*
@@ -124,26 +136,31 @@ int parse_set_options(char **args, int args_count, SetOptions *options) {
 }
 
 void handle_ping(CommandHandler *ch) {
+  printf("handling ping\n");
+  fflush(stdout);
+  Client *client = ch->client;
   if (ch->arg_count == 1) {
-    add_simple_string_reply(ch->client, "PONG");
+    add_simple_string_reply(client->output_buffer, "PONG");
   } else if (ch->arg_count == 2) {
-    add_simple_string_reply(ch->client, ch->args[1]);
+    add_simple_string_reply(client->output_buffer, ch->args[1]);
   } else {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'ping' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'ping' command");
   }
 }
 
 void handle_echo(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count != 2) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'echo' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'echo' command");
     return;
   }
-  add_simple_string_reply(ch->client, ch->args[1]);
+  add_simple_string_reply(client->output_buffer, ch->args[1]);
 }
 
 void handle_set(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 3) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'set' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'set' command");
     return;
   }
 
@@ -152,15 +169,15 @@ void handle_set(CommandHandler *ch) {
 
   switch (parse_result) {
   case ERR_SYNTAX:
-    add_error_reply(ch->client, "ERR syntax error");
+    add_error_reply(client->output_buffer, "ERR syntax error");
     return;
   case ERR_VALUE:
-    add_error_reply(ch->client, "ERR value is not an integer or out of range");
+    add_error_reply(client->output_buffer, "ERR value is not an integer or out of range");
     return;
   }
 
   if (options.expiration < 0) {
-    add_error_reply(ch->client, "ERR expiration must be a non-negative integer");
+    add_error_reply(client->output_buffer, "ERR expiration must be a non-negative integer");
     return;
   }
 
@@ -171,14 +188,14 @@ void handle_set(CommandHandler *ch) {
   // only get the existing value if we need to check conditions (NX, XX) or respond to GET
   // option
   if (options.nx || options.xx || options.get || options.keepttl) {
-    existing_value = redis_db_get(ch->client->db, ch->args[1]);
+    existing_value = redis_db_get(client->db, ch->args[1]);
     if (existing_value != NULL) {
       key_exists = true;
     }
   }
 
   if ((options.nx && key_exists) || (options.xx && !key_exists)) {
-    add_null_reply(ch->client);
+    add_null_reply(client->output_buffer);
     return;
   }
 
@@ -193,78 +210,83 @@ void handle_set(CommandHandler *ch) {
     }
   }
 
-  redis_db_set(ch->client->db, ch->args[1], ch->args[2], TYPE_STRING, expiration);
+  redis_db_set(client->db, ch->args[1], ch->args[2], TYPE_STRING, expiration);
 
   if (options.get) {
     if (old_value) {
-      add_bulk_string_reply(ch->client, old_value);
+      add_bulk_string_reply(client->output_buffer, old_value);
       free(old_value);
     } else {
-      add_null_reply(ch->client);
+      add_null_reply(client->output_buffer);
     }
   } else {
-    add_simple_string_reply(ch->client, "OK");
+    add_simple_string_reply(client->output_buffer, "OK");
   }
 }
 
 void handle_get(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count != 2) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'get' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'get' command");
     return;
   }
 
-  RedisValue *redis_value = redis_db_get(ch->client->db, ch->args[1]);
+  RedisValue *redis_value = redis_db_get(client->db, ch->args[1]);
   if (redis_value == NULL) {
-    add_null_reply(ch->client);
+    add_null_reply(client->output_buffer);
   } else if (redis_value->type != TYPE_STRING) {
-    add_error_reply(ch->client, "ERR Operation against a key holding the wrong kind of value");
+    add_error_reply(client->output_buffer,
+                    "ERR Operation against a key holding the wrong kind of value");
   } else {
-    add_bulk_string_reply(ch->client, redis_value->data.str);
+    add_bulk_string_reply(client->output_buffer, redis_value->data.str);
   }
 }
 
 void handle_exist(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 2) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'exist' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'exist' command");
     return;
   }
 
   int count = 0;
   for (int i = 1; i < ch->arg_count; i++) {
-    if (redis_db_exist(ch->client->db, ch->args[i])) {
+    if (redis_db_exist(client->db, ch->args[i])) {
       count += 1;
     }
   }
 
-  add_integer_reply(ch->client, count);
+  add_integer_reply(client->output_buffer, count);
 }
 
 void handle_delete(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 2) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'delete' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'delete' command");
     return;
   }
 
   for (int i = 1; i < ch->arg_count; i++) {
-    redis_db_delete(ch->client->db, ch->args[i]);
+    redis_db_delete(client->db, ch->args[i]);
   }
-  add_simple_string_reply(ch->client, "OK");
+  add_simple_string_reply(client->output_buffer, "OK");
 }
 
 void handle_incr_decr(CommandHandler *ch, int increment) {
+  Client *client = ch->client;
   if (ch->arg_count < 2) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'incr/decr' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'incr/decr' command");
     return;
   }
 
-  RedisValue *redis_value = redis_db_get(ch->client->db, ch->args[1]);
+  RedisValue *redis_value = redis_db_get(client->db, ch->args[1]);
   long current_value = 0;
 
   // check if the key exists and parse its value
   if (redis_value != NULL) {
     int parse_result = parse_integer(redis_value->data.str, &current_value);
     if (parse_result == ERR_VALUE) {
-      add_error_reply(ch->client, "ERR value is not an integer");
+      add_error_reply(client->output_buffer, "ERR value is not an integer");
       return;
     }
   } else {
@@ -278,8 +300,8 @@ void handle_incr_decr(CommandHandler *ch, int increment) {
   snprintf(new_value_str, sizeof(new_value_str), "%ld", new_value);
 
   // set the new value in the database
-  redis_db_set(ch->client->db, ch->args[1], new_value_str, TYPE_STRING, 0);
-  add_integer_reply(ch->client, new_value);
+  redis_db_set(client->db, ch->args[1], new_value_str, TYPE_STRING, 0);
+  add_integer_reply(client->output_buffer, new_value);
 }
 
 void handle_incr(CommandHandler *ch) { handle_incr_decr(ch, 1); }
@@ -287,42 +309,47 @@ void handle_incr(CommandHandler *ch) { handle_incr_decr(ch, 1); }
 void handle_decr(CommandHandler *ch) { handle_incr_decr(ch, -1); }
 
 void handle_lpush(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 3) { // at least 2 arguments: key and one element
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'lpush' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'lpush' command");
     return;
   }
   const char *key = ch->args[1];
   int length = 0;
   for (int i = 2; i < ch->arg_count; i++) {
-    int result = redis_db_lpush(ch->client->db, key, ch->args[i], &length); // capture the result
+    int result = redis_db_lpush(client->db, key, ch->args[i], &length); // capture the result
     if (result == ERR_TYPE_MISMATCH) { // check for type mismatch error
-      add_error_reply(ch->client, "ERR Operation against a key holding the wrong kind of value");
+      add_error_reply(client->output_buffer,
+                      "ERR Operation against a key holding the wrong kind of value");
       return;
     }
   }
-  add_integer_reply(ch->client, length);
+  add_integer_reply(client->output_buffer, length);
 }
 
 void handle_rpush(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 3) { // at least 2 arguments: key and one element
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'rpush' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'rpush' command");
     return;
   }
   const char *key = ch->args[1];
   int length = 0; // stores the length of the list after operation
   for (int i = 2; i < ch->arg_count; i++) {
-    int result = redis_db_rpush(ch->client->db, key, ch->args[i], &length); //
+    int result = redis_db_rpush(client->db, key, ch->args[i], &length); //
     if (result == ERR_TYPE_MISMATCH) { // check for type mismatch error
-      add_error_reply(ch->client, "ERR Operation against a key holding the wrong kind of value");
+      add_error_reply(client->output_buffer,
+                      "ERR Operation against a key holding the wrong kind of value");
       return;
     }
   }
-  add_integer_reply(ch->client, length);
+  add_integer_reply(client->output_buffer, length);
 }
 
 void handle_lrange(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 4) { // needs 3 arguments: LRANGE key start end
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'rpush' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'rpush' command");
     return;
   }
 
@@ -334,19 +361,22 @@ void handle_lrange(CommandHandler *ch) {
   parse_integer(ch->args[2], &start);
   parse_integer(ch->args[3], &end);
 
-  int error = redis_db_lrange(ch->client->db, list_key, start, end, &range, &range_length);
+  int error = redis_db_lrange(client->db, list_key, start, end, &range, &range_length);
   if (error == ERR_TYPE_MISMATCH) { // check for type mismatch error
-    add_error_reply(ch->client, "ERR Operation against a key holding the wrong kind of value");
+    add_error_reply(client->output_buffer,
+                    "ERR Operation against a key holding the wrong kind of value");
     return;
   }
 
-  add_array_reply(ch->client, range, range_length);
+  add_array_reply(client->output_buffer, range, range_length);
   cleanup_lrange_result(range, range_length);
 }
 
 void handle_config(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count < 3) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'config get' command");
+    add_error_reply(client->output_buffer,
+                    "ERR wrong number of arguments for 'config get' command");
     return;
   }
 
@@ -364,37 +394,40 @@ void handle_config(CommandHandler *ch) {
         response[response_index++] = "dbfilename";
         response[response_index++] = g_server_config.dbfilename;
       } else {
-        add_error_reply(ch->client, "ERR Unknown config parameter");
+        add_error_reply(client->output_buffer, "ERR Unknown config parameter");
         return;
       }
     }
-    add_array_reply(ch->client, response, response_index);
+    add_array_reply(client->output_buffer, response, response_index);
   }
 }
 
 void handle_save(CommandHandler *ch) {
+  Client *client = ch->client;
   if (ch->arg_count != 1) {
-    add_error_reply(ch->client, "ERR wrong number of arguments for 'save' command");
+    add_error_reply(client->output_buffer, "ERR wrong number of arguments for 'save' command");
   }
 
-  redis_db_save(ch->client->db);
+  redis_db_save(client->db);
 
-  add_simple_string_reply(ch->client, "OK");
+  add_simple_string_reply(client->output_buffer, "OK");
 }
 
 // gets the key count for the currently selected db
 void handle_dbsize(CommandHandler *ch) {
-  size_t dbsize = redis_db_dbsize(ch->client->db);
+  Client *client = ch->client;
+  size_t dbsize = redis_db_dbsize(client->db);
 
   int size = (int)dbsize;
 
-  add_integer_reply(ch->client, size);
+  add_integer_reply(client->output_buffer, size);
 }
 
 void handle_info(CommandHandler *ch) {
+  Client *client = ch->client;
   // only support the "role" key for now
   char info_output_buffer[INFO_BUFFER_SIZE];
-  int current_offset;
+  int current_offset = 0;
   current_offset += snprintf(info_output_buffer + current_offset,
                              sizeof(info_output_buffer) - current_offset, "# Replication\r\n");
 
@@ -409,5 +442,116 @@ void handle_info(CommandHandler *ch) {
   current_offset +=
       snprintf(info_output_buffer + current_offset, sizeof(info_output_buffer) - current_offset,
                "master_repl_offset:%lld\r\n", g_server_info.master_repl_offset);
-  add_bulk_string_reply(ch->client, info_output_buffer);
+  add_bulk_string_reply(client->output_buffer, info_output_buffer);
+}
+
+void handle_replconf(CommandHandler *ch) {
+  add_simple_string_reply(ch->client->output_buffer, "OK");
+}
+
+void handle_simple_string_reply(CommandHandler *ch) {
+  Client *client = ch->client;
+  char *reply = ch->buf;
+  if (ch->client->type == CLIENT_TYPE_MASTER) {
+    // replica is handling responses from master
+    ReplicaClientState repl_client_state = client->repl_client_state;
+    if (repl_client_state == REPL_STATE_SENT_PING) {
+      if (strcmp(reply, "PONG") == 0) {
+        client->repl_client_state = REPL_STATE_RECEIVED_PONG;
+      } else {
+        fprintf(stderr, "expected PONG in REPL_STATE_SENT_PING, got '%s'\n", reply);
+        client->repl_client_state = REPL_STATE_ERROR;
+      }
+    } else if (repl_client_state == REPL_STATE_SENT_REPLCONF_PORT) {
+      if (strcmp(reply, "OK") == 0) {
+        client->repl_client_state = REPL_STATE_RECEIVED_REPLCONF_PORT_OK;
+      } else {
+        fprintf(stderr, "expected OK in REPL_STATE_SENT_REPLCONF_PORT, got '%s'\n", reply);
+        client->repl_client_state = REPL_STATE_ERROR;
+      }
+    } else if (repl_client_state == REPL_STATE_SENT_REPLCONF_CAPA) {
+      if (strcmp(reply, "OK") == 0) {
+        client->repl_client_state = REPL_STATE_RECEIVED_REPLCONF_CAPA_OK;
+      } else {
+        fprintf(stderr, "error: expected OK in REPL_STATE_SENT_REPLCONF_CAPA, got '%s'\n", reply);
+        client->repl_client_state = REPL_STATE_ERROR;
+      };
+    } else if (repl_client_state == REPL_STATE_SENT_PSYNC) {
+      if (strncmp(reply, "FULLRESYNC", 9) == 0) {
+        sscanf("FULLRESYNC %40s %lld", g_server_info.master_replid,
+               g_server_info.master_repl_offset);
+
+        printf("Replica sync: Master ID: %s, Offset: %lld\n", g_server_info.master_replid,
+               g_server_info.master_repl_offset);
+        client->repl_client_state = REPL_STATE_RECEIVED_FULLRESYNC_RESPONSE;
+      } else {
+        fprintf(stderr, "error: expected reply in REPL_STATE_SENT_PSYNC, got '%s'\n", reply);
+        client->repl_client_state = REPL_STATE_ERROR;
+      }
+    }
+  }
+}
+
+void handle_psync(CommandHandler *ch) {
+  Client *client = ch->client;
+  add_psync_reply(client->output_buffer, g_server_info.master_replid,
+                  g_server_info.master_repl_offset);
+  client->type = CLIENT_TYPE_REPLICA;
+  // send $<length_of_file>\r\n<file_content>
+  // call save
+  redis_db_save(client->db);
+
+  char *db_file_path = construct_file_path(g_server_config.dir, g_server_config.dbfilename);
+  printf("%s\n", db_file_path);
+  FILE *file = fopen(db_file_path, "rb");
+  if (!file) {
+    perror("Failed to open RDB file or it does not exist\n");
+  }
+  int rdb_file_fd = fileno(file);
+  struct stat statbuf;
+  fstat(rdb_file_fd, &statbuf);
+  off_t db_file_size = (off_t)statbuf.st_size;
+
+  client->rdb_fd = rdb_file_fd;
+  client->rdb_file_size = db_file_size;
+  printf("rdb file size: %ld\n", db_file_size);
+  client->rdb_file_offset = 0;
+
+  client->master_repl_state = MASTER_REPL_STATE_SENDING_RDB_DATA;
+  write_begin_bulk_string(client->output_buffer, (int64_t)db_file_size);
+  client_enable_write_events(client);
+}
+
+void send_ping_command(Client *client) {
+  char *ping_cmd[] = {"PING"};
+  add_array_reply(client->output_buffer, ping_cmd, 1);
+  flush_client_output(client);
+  client->repl_client_state = REPL_STATE_SENT_PING;
+  printf("sent ping command\n");
+}
+
+void send_replconf_listening_port_command(Client *client, char *replica_port) {
+  char *args[3] = {"REPLCONF", "listening-port", replica_port};
+  add_array_reply(client->output_buffer, args, 3);
+  flush_client_output(client);
+  client->repl_client_state = REPL_STATE_SENT_REPLCONF_PORT;
+  printf("sent repl conf listening port\n");
+}
+
+void send_replconf_capa_command(Client *client) {
+  // safely hardcode capabilites for now
+  char *args[3] = {"REPLCONF", "capa", "psync2"};
+  add_array_reply(client->output_buffer, args, 3);
+  flush_client_output(client);
+  client->repl_client_state = REPL_STATE_SENT_REPLCONF_CAPA;
+  printf("sent replconf capa command with args: capa psync2\n");
+}
+
+void send_psync_command(Client *client) {
+  // initially hardcode PSYNC ? -1, for testing handshake
+  char *args[3] = {"PSYNC", "?", "-1"};
+  add_array_reply(client->output_buffer, args, 3);
+  flush_client_output(client);
+  client->repl_client_state = REPL_STATE_SENT_PSYNC;
+  printf("sent psync command with args: ? -1\n");
 }

--- a/src/commands.h
+++ b/src/commands.h
@@ -3,6 +3,7 @@
 
 #include "command_handler.h"
 #include "resp.h"
+#include "ring_buffer.h"
 
 typedef struct {
   long long expiration; // expiration time in milliseconds sinch epoch
@@ -27,6 +28,16 @@ void handle_config(CommandHandler *ch);
 void handle_save(CommandHandler *ch);
 void handle_dbsize(CommandHandler *ch);
 void handle_info(CommandHandler *ch);
-void add_error_reply(Client *client, const char *str);
+void handle_replconf(CommandHandler *ch);
+void handle_psync(CommandHandler *ch);
+
+void handle_simple_string_reply(CommandHandler *ch);
+
+void send_ping_command(Client *client);
+
+// send replication handshake specific commands
+void send_replconf_listening_port_command(Client *client, char *replica_port);
+void send_replconf_capa_command(Client *client);
+void send_psync_command(Client *client);
 
 #endif // COMMAND_H

--- a/src/handler.h
+++ b/src/handler.h
@@ -1,6 +1,7 @@
 #ifndef HANDLER_H
 #define HANDLER_H
 
+#include "command_handler.h"
 #include <stdint.h>
 
 struct CommandHandler;
@@ -19,7 +20,7 @@ typedef struct Handler {
   void (*end_integer)(struct CommandHandler *ch);
 } Handler;
 
-extern Handler *handler;
+extern Handler *g_handler;
 
 Handler *create_handler();
 void destroy_handler(Handler *handler);

--- a/src/handler.h
+++ b/src/handler.h
@@ -19,6 +19,8 @@ typedef struct Handler {
   void (*end_integer)(struct CommandHandler *ch);
 } Handler;
 
+extern Handler *handler;
+
 Handler *create_handler();
 void destroy_handler(Handler *handler);
 

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -1,9 +1,12 @@
 #ifndef RDB_H
 #define RDB_H
 
+#include "client.h"
 #include "database.h"
 
 int rdb_load_data_from_file(redis_db_t *db, const char *dir, const char *filename);
 bool rdb_save_data_to_file(redis_db_t *db, const char *dir, const char *filename);
+void master_send_rdb_snapshot(Client *client);
+void replica_receive_rdb_snapshot(Client *client);
 
 #endif // RDB_H

--- a/src/redis-server.c
+++ b/src/redis-server.c
@@ -1,4 +1,6 @@
 #include "arpa/inet.h"
+#include <errno.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <signal.h>
@@ -12,12 +14,14 @@
 
 #include "client.h"
 #include "command_handler.h"
+#include "commands.h"
 #include "database.h"
 #include "rdb.h"
 #include "redis-server.h"
+#include "replication.h"
 #include "resp.h"
 #include "server_config.h"
-#include <errno.h>
+#include "util.h"
 
 #define DEFAULT_PORT 6379
 #define MAX_EVENTS 10000
@@ -27,92 +31,25 @@ server_config_t g_server_config = {.dir = "/tmp/redis-data", .dbfilename = "dump
 
 server_info_t g_server_info = {.role = "master",
                                .master_replid =
-                                   "0000000000000000000000000000000000000000", // hard code for now
+                                   "8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb", // hard code for now
                                .master_repl_offset = 0};
 
-void process_client_input(Client *client, int epfd) {
-  for (;;) {
-
-    char *write_buf;
-    size_t writable_len;
-
-    // get the writable portion of the ring buffer
-    if (rb_writable(client->input_buffer, &write_buf, &writable_len) != 0) {
-      fprintf(stderr, "failed to get writable buffer\n");
-      return;
-    }
-
-    if (writable_len == 0) {
-      fprintf(stderr, "input buffer full\n");
-      return;
-    }
-
-    // read from the socket into the writable portion of the ring buffer
-    ssize_t bytes_received = read(client->fd, write_buf, writable_len);
-
-    switch (bytes_received) {
-    case -1:
-      if (errno == EINTR) {
-        continue;
-      } else if (errno == EWOULDBLOCK) {
-        flush_client_output(client);
-        return;
-      } else {
-        perror("failed to read from client socket");
-        return;
-      }
-    case 0:
-      handle_client_disconnection(client, epfd);
-      fprintf(stderr, "client disconnected\n");
-      return;
-    default:
-      // update the write index of the ring buffer
-      if (rb_write(client->input_buffer, bytes_received) != 0) {
-        fprintf(stderr, "failed to update write index\n");
-        return;
-      }
-    }
-
-    char *read_buf;
-    size_t readable_len;
-
-    // get the readable portion of the ring buffer
-    if (rb_readable(client->input_buffer, &read_buf, &readable_len) != 0) {
-      fprintf(stderr, "failed to get readable buffer\n");
-      return;
-    }
-
-    const char *begin = read_buf;
-    const char *end = read_buf + readable_len;
-
-    size_t bytes_parsed = parser_parse(client->parser, begin, end) - begin;
-
-    if (rb_read(client->input_buffer, bytes_parsed)) {
-      fprintf(stderr, "failed to update read index\n");
-      return;
-    }
-
-    if (bytes_received < writable_len) {
-      flush_client_output(client);
-      return;
-    }
-  }
-}
-
-void handle_client_disconnection(Client *client, int epfd) {
-  epoll_ctl(epfd, EPOLL_CTL_DEL, client->fd, NULL);
-  destroy_client(client);
-}
+Handler *handler;
+int g_epoll_fd; // epollfd global
+int port = DEFAULT_PORT;
 
 volatile sig_atomic_t stop_server = 0;
 
 void sigint_handler(int sig) { stop_server = 1; }
 
 int start_server(int argc, char *argv[]) {
-  // printf("default directory: %s\n", g_server_config.dir);
-  // printf("default db filename: %s\n", g_server_config.dbfilename);
-
-  int port = DEFAULT_PORT;
+  handler = create_handler();
+  redis_db_t *db = redis_db_create();
+  g_epoll_fd = epoll_create(1);
+  if (g_epoll_fd == -1) {
+    perror("epoll_create failed");
+    exit(EXIT_FAILURE);
+  }
 
   // parse command-line args
   for (int i = 1; i < argc; i++) {
@@ -128,23 +65,92 @@ int start_server(int argc, char *argv[]) {
       }
     } else if (strcmp(argv[i], "--port") == 0) {
       if (i + 1 < argc) {
+        strcpy(g_server_config.port, argv[i + 1]);
         port = atoi(argv[i + 1]);
         i++;
       }
     } else if (strcmp(argv[i], "--replicaof") == 0) {
       if (i + 2 < argc) {
         strcpy(g_server_info.role, "slave");
+        strcpy(g_server_config.master_host, argv[i + 1]);
+        strcpy(g_server_config.master_port, argv[i + 2]);
         i += 2;
       }
+    }
+  }
+
+  if (strcmp(g_server_info.role, "slave") == 0) {
+    int master_fd;
+    char port_str[6];
+
+    // resolve address
+    struct addrinfo hints, *res;
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    int status =
+        getaddrinfo(g_server_config.master_host, g_server_config.master_port, &hints, &res);
+    if (status != 0) {
+      fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(status));
+      exit(EXIT_FAILURE);
+    }
+
+    // loop through all the results and connect to the first one we can
+    bool connected = false;
+    struct addrinfo *p;
+    for (p = res; p != NULL; p = p->ai_next) {
+
+      // create socket
+      master_fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+      if (master_fd == -1) {
+        perror("cannot create socket for master connection");
+        exit(EXIT_FAILURE);
+      }
+
+      // connect to master
+      if (connect(master_fd, p->ai_addr, p->ai_addrlen) == -1) {
+        close(master_fd);
+        continue;
+      }
+
+      connected = true;
+      break;
+    }
+
+    freeaddrinfo(res);
+
+    if (!connected) {
+      perror("Replica: failed to connect to master...\n");
+      exit(EXIT_FAILURE);
+    }
+
+    Client *master_client = create_client(master_fd);
+    set_non_blocking(master_fd);
+    master_client->db = db;
+    master_client->type = CLIENT_TYPE_MASTER;
+    master_client->repl_client_state = REPL_STATE_CONNECTING;
+
+    CommandHandler *command_handler = create_command_handler(master_client, 256, 10);
+    parser_init(master_client->parser, command_handler);
+
+    struct epoll_event event;
+    event.events = EPOLLIN | EPOLLOUT;
+    event.data.fd = master_fd;
+    event.data.ptr = master_client;
+
+    if (epoll_ctl(g_epoll_fd, EPOLL_CTL_ADD, master_fd, &event) == -1) {
+      perror("epoll_ctl for master_fd failed");
+      exit(EXIT_FAILURE);
     }
   }
 
   // register the signal handler
   signal(SIGINT, sigint_handler);
 
-  redis_db_t *db = redis_db_create();
-
-  rdb_load_data_from_file(db, g_server_config.dir, g_server_config.dbfilename);
+  if (strcmp(g_server_info.role, "slave") != 0) {
+    // for now only load file if it is not a replica
+    rdb_load_data_from_file(db, g_server_config.dir, g_server_config.dbfilename);
+  }
 
   struct sockaddr_in sa;
   int SocketFD = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -182,18 +188,13 @@ int start_server(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  int epfd = epoll_create(1);
-  if (epfd == -1) {
-    perror("epoll_create1 failed");
-    exit(EXIT_FAILURE);
-  }
+  set_non_blocking(SocketFD);
 
   struct epoll_event event;
   event.events = EPOLLIN; // EPOLLIN is the flag for read events
-  // event.data.fd = SocketFD;
   event.data.ptr = NULL;
 
-  if (epoll_ctl(epfd, EPOLL_CTL_ADD, SocketFD, &event) == -1) {
+  if (epoll_ctl(g_epoll_fd, EPOLL_CTL_ADD, SocketFD, &event) == -1) {
     perror("epoll_ctl failed");
     exit(EXIT_FAILURE);
   }
@@ -201,11 +202,9 @@ int start_server(int argc, char *argv[]) {
   struct epoll_event events[MAX_EVENTS];
   int num_events;
 
-  Handler *handler = create_handler();
-
   printf("# Ready to accept connections\n");
   for (;;) {
-    num_events = epoll_wait(epfd, events, MAX_EVENTS, -1);
+    num_events = epoll_wait(g_epoll_fd, events, MAX_EVENTS, -1);
     if (num_events == -1 && errno != EINTR) {
       perror("epoll_wait failed");
       exit(EXIT_FAILURE);
@@ -214,6 +213,7 @@ int start_server(int argc, char *argv[]) {
     // iterate through the events
     for (int i = 0; i < num_events; i++) {
       struct epoll_event *current_event = &events[i];
+      Client *client = (Client *)current_event->data.ptr;
       if (!current_event->data.ptr) { // server socket is ready, new connection
         int ConnectFD = accept(SocketFD, NULL, NULL);
         if (ConnectFD == -1) {
@@ -222,28 +222,37 @@ int start_server(int argc, char *argv[]) {
           exit(EXIT_FAILURE);
         }
 
-        Client *client = create_client(ConnectFD, handler);
-        select_client_db(client, db);
-        CommandHandler *command_handler = create_command_handler(client, 256, 10);
-        parser_init(client->parser, handler, command_handler);
+        set_non_blocking(ConnectFD);
+
+        Client *new_client = create_client(ConnectFD);
+
+        new_client->type = CLIENT_TYPE_REGULAR;
+        select_client_db(new_client, db);
+        CommandHandler *command_handler = create_command_handler(new_client, 256, 10);
+        parser_init(new_client->parser, command_handler);
 
         int optval = 1;
         setsockopt(ConnectFD, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
 
         event.events = EPOLLIN;
+        new_client->epoll_events = event.events;
         event.data.fd = ConnectFD;
-        event.data.ptr = client;
+        event.data.ptr = new_client;
 
-        if (epoll_ctl(epfd, EPOLL_CTL_ADD, ConnectFD, &event) == -1) {
+        if (epoll_ctl(g_epoll_fd, EPOLL_CTL_ADD, ConnectFD, &event) == -1) {
           perror("epoll_ctl failed");
           exit(EXIT_FAILURE);
         }
       } else if (events[i].events & EPOLLIN) {
-        Client *client = (Client *)current_event->data.ptr;
-        process_client_input(client, epfd);
+        process_client_input(client);
+      } else if (events[i].events & EPOLLOUT) {
+        if (client->type == CLIENT_TYPE_REPLICA) {
+          master_handle_replica_out(client);
+        } else if (client->type == CLIENT_TYPE_MASTER) {
+          replica_handle_master_data(client);
+        }
       } else if (events[i].events & EPOLLHUP | EPOLLERR) {
-        Client *client = (Client *)current_event->data.ptr;
-        handle_client_disconnection(client, epfd);
+        handle_client_disconnection(client);
       } else {
         fprintf(stderr, "Unexpected event type: %d\n", events[i].events);
       }
@@ -254,13 +263,13 @@ int start_server(int argc, char *argv[]) {
       break;
     }
   }
-  close(epfd);
+  close(g_epoll_fd);
   close(SocketFD);
   // saves the currently selected db
   // TODO when we support multiple databases, save all of the databases
   printf("# Saving the final RDB snapshot before exiting.\n");
   if (redis_db_save(db)) {
-    printf("# DB saved on disk");
+    printf("# DB saved on disk\n");
   }
   redis_db_destroy(db);
   destroy_handler(handler);

--- a/src/redis-server.c
+++ b/src/redis-server.c
@@ -1,4 +1,15 @@
+#include "redis-server.h"
 #include "arpa/inet.h"
+#include "client.h"
+#include "command_handler.h"
+#include "commands.h"
+#include "database.h"
+#include "rdb.h"
+#include "replication.h"
+#include "resp.h"
+#include "ring_buffer.h"
+#include "server_config.h"
+#include "util.h"
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -12,17 +23,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#include "client.h"
-#include "command_handler.h"
-#include "commands.h"
-#include "database.h"
-#include "rdb.h"
-#include "redis-server.h"
-#include "replication.h"
-#include "resp.h"
-#include "server_config.h"
-#include "util.h"
-
 #define DEFAULT_PORT 6379
 #define MAX_EVENTS 10000
 #define MAX_PATH_LENGTH 256
@@ -34,10 +34,8 @@ server_info_t g_server_info = {.role = "master",
                                    "8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb", // hard code for now
                                .master_repl_offset = 0};
 
-Handler *handler;
 int g_epoll_fd; // epollfd global
 int port = DEFAULT_PORT;
-
 volatile sig_atomic_t stop_server = 0;
 
 void sigint_handler(int sig) { stop_server = 1; }

--- a/src/redis-server.h
+++ b/src/redis-server.h
@@ -8,13 +8,18 @@ extern "C" {
 #include "command_handler.h"
 #include "khash.h"
 #include "resp.h"
+#include <sys/epoll.h>
 
 // foward declarations
 struct CommandHandler;
 
-void handle_client_disconnection(Client *client, int epfd);
+void handle_client_disconnection(Client *client);
 
 int start_server();
+
+extern int g_epoll_fd; // global epoll fd
+void client_enable_write_events(Client *client);
+void client_disable_write_events(Client *client);
 
 #ifdef __cplusplus
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1,0 +1,101 @@
+#include "replication.h"
+#include "commands.h"
+#include "rdb.h"
+#include <stdio.h>
+
+void master_handle_replica_out(Client *client) {
+  MasterReplicaState master_repl_state = client->master_repl_state;
+  switch (master_repl_state) {
+  case MASTER_REPL_STATE_SENDING_RDB_DATA:
+    master_send_rdb_snapshot(client);
+    break;
+  }
+}
+
+void replica_handle_master_data(Client *master_client) {
+  switch (master_client->repl_client_state) {
+  case REPL_STATE_CONNECTING:
+    send_ping_command(master_client);
+    master_client->repl_client_state = REPL_STATE_SENT_PING;
+    break;
+  case REPL_STATE_RECEIVED_PONG:
+    send_replconf_listening_port_command(master_client, g_server_config.port);
+    master_client->repl_client_state = REPL_STATE_SENT_REPLCONF_PORT;
+    break;
+  case REPL_STATE_RECEIVED_REPLCONF_PORT_OK:
+    send_replconf_capa_command(master_client);
+    master_client->repl_client_state = REPL_STATE_SENT_REPLCONF_CAPA;
+    break;
+  case REPL_STATE_RECEIVED_REPLCONF_CAPA_OK:
+    send_psync_command(master_client);
+    master_client->repl_client_state = REPL_STATE_SENT_PSYNC;
+    break;
+  case REPL_STATE_RECEIVED_FULLRESYNC_RESPONSE:
+    char *read_buf;
+    size_t readable_len;
+
+    if (rb_readable(master_client->input_buffer, &read_buf, &readable_len) != 0) {
+      fprintf(stderr, "Failed to get readable buffer for client %d\n", master_client->fd);
+      return; // error getting buffer state
+    }
+
+    if (readable_len < 4) {
+      // not enough data for even a minimal header
+      return;
+    }
+
+    // first character must be $
+    if (read_buf[0] != '$') {
+      fprintf(stderr, "protocol error for client %d, expected '$' for RDB header, got %c\n",
+              master_client->fd, read_buf[0]);
+    }
+
+    char *crlf_pos = NULL;
+    for (size_t i = 0; i < readable_len - 1; i++) {
+      if (read_buf[i] == '\r' && read_buf[i + 1] == '\n') {
+        crlf_pos = read_buf + i;
+        break;
+      }
+    }
+
+    if (crlf_pos == NULL) {
+      // \r\n not found yet, need more data to complete the header
+      return;
+    }
+
+    // calculate length between the $ and \r\n
+    size_t size_str_len = crlf_pos - (read_buf + 1);
+    if (size_str_len == 0) {
+      fprintf(stderr,
+              "error in parsing bulk string header for rdb transfer, empty rdb size string\n");
+    }
+
+    int64_t length = 0;
+
+    char *end_ptr;
+    length = strtol(read_buf + 1, &end_ptr, 10);
+
+    size_t bytes_to_consume =
+        (crlf_pos - read_buf) + 2; // length from read_buf to \r, plus 2 for \r\n
+    if (rb_read(master_client->input_buffer, bytes_to_consume) != 0) {
+      fprintf(stderr, "failed to consume RDB header from buffer for client %d\n",
+              master_client->fd);
+      return;
+    }
+
+    master_client->rdb_expected_bytes = length;
+    master_client->rdb_received_bytes = 0;
+    master_client->repl_client_state = REPL_STATE_RECEIVING_RDB_DATA;
+
+    // proceed to receive RDB data, as some might already be in the buffer
+    // after the header was confused
+    replica_receive_rdb_snapshot(master_client);
+    break;
+  case REPL_STATE_RECEIVING_RDB_DATA:
+    replica_receive_rdb_snapshot(master_client);
+    break;
+  case REPL_STATE_READY:
+    break;
+  default:
+  }
+}

--- a/src/replication.h
+++ b/src/replication.h
@@ -1,0 +1,11 @@
+#ifndef REPLICATION_H
+#define REPLICATION_H
+
+#include "client.h"
+#include "database.h"
+#include "server_config.h"
+
+void master_handle_replica_out(Client *client);
+void replica_handle_master_data(Client *master_client);
+
+#endif // REPLICATION.H

--- a/src/resp.c
+++ b/src/resp.c
@@ -1,4 +1,5 @@
 #include "resp.h"
+#include "handler.h"
 #include "ring_buffer.h"
 #include <errno.h>
 #include <limits.h>
@@ -177,8 +178,7 @@ ParseResult parse_bulk_string(Parser *parser, const char *begin, const char *end
 ParseResult parse_array(Parser *parser, const char *begin, const char *end);
 ParseResult parse_inline_command(Parser *parser, const char *begin, const char *end);
 
-void parser_init(Parser *parser, Handler *handler, CommandHandler *command_handler) {
-  parser->handler = handler;
+void parser_init(Parser *parser, CommandHandler *command_handler) {
   parser->command_handler = command_handler;
   parser->stack_top = 0;
   parser->stack[0] = (StateInfo){STATE_INITIAL_TERMINAL, 0, parse_initial};
@@ -201,6 +201,14 @@ void pop_state(Parser *parser) {
 const char *parser_parse(Parser *parser, const char *begin, const char *end) {
   bool keep_going = true;
   while (keep_going) {
+    if (parser->command_handler->client->type == CLIENT_TYPE_MASTER &&
+        parser->command_handler->client->repl_client_state ==
+            REPL_STATE_RECEIVED_FULLRESYNC_RESPONSE) {
+      // we are expecting the $<file_size>\r\n header before the rdb file contents
+      // are streamed, we do not want this parser to consume any bytes, another
+      // parser will take care of that
+      return begin;
+    }
     ParseResult result = parser->stack[parser->stack_top].parse(parser, begin, end);
     keep_going = result.keep_going;
     begin = result.new_begin;
@@ -221,23 +229,23 @@ ParseResult parse_initial(Parser *parser, const char *begin, const char *end) {
 
   switch (*begin) {
   case '+':
-    parser->handler->begin_simple_string(parser->command_handler);
-    push_state(parser, STATE_SIMPLE, 0, parse_simple, parser->handler->end_simple_string);
+    handler->begin_simple_string(parser->command_handler);
+    push_state(parser, STATE_SIMPLE, 0, parse_simple, handler->end_simple_string);
     break;
   case '-':
-    parser->handler->begin_error(parser->command_handler);
-    push_state(parser, STATE_SIMPLE, 0, parse_simple, parser->handler->end_error);
+    handler->begin_error(parser->command_handler);
+    push_state(parser, STATE_SIMPLE, 0, parse_simple, handler->end_error);
     break;
   case ':':
-    push_state(parser, STATE_SIMPLE, 0, parse_simple, parser->handler->end_integer);
-    parser->handler->begin_integer(parser->command_handler);
+    push_state(parser, STATE_SIMPLE, 0, parse_simple, handler->end_integer);
+    handler->begin_integer(parser->command_handler);
     break;
   case '$':
-    push_state(parser, STATE_BULK_STRING_LENGTH, 0, parse_length, parser->handler->end_bulk_string);
+    push_state(parser, STATE_BULK_STRING_LENGTH, 0, parse_length, handler->end_bulk_string);
     // don't call begin_bulk_string yet, we need the length first
     break;
   case '*':
-    push_state(parser, STATE_ARRAY_LENGTH, 0, parse_length, parser->handler->end_array);
+    push_state(parser, STATE_ARRAY_LENGTH, 0, parse_length, handler->end_array);
     // don't call begin_array yet, we need the length first
     break;
 
@@ -257,7 +265,7 @@ ParseResult parse_simple(Parser *parser, const char *begin, const char *end) {
   }
 
   // process the characters up to CR
-  parser->handler->chars(parser->command_handler, begin, pos);
+  handler->chars(parser->command_handler, begin, pos);
 
   if (end - pos < 2) {
     return (ParseResult){false, pos};
@@ -300,14 +308,13 @@ ParseResult parse_length(Parser *parser, const char *begin, const char *end) {
   if (parser->stack[parser->stack_top].type == STATE_ARRAY_LENGTH) {
     // remove the length state
     pop_state(parser);
-    parser->handler->begin_array(parser->command_handler, int_length);
-    push_state(parser, STATE_ARRAY, int_length, parse_array, parser->handler->end_array);
+    handler->begin_array(parser->command_handler, int_length);
+    push_state(parser, STATE_ARRAY, int_length, parse_array, handler->end_array);
   } else if (parser->stack[parser->stack_top].type == STATE_BULK_STRING_LENGTH) {
     // remove the length state
     pop_state(parser);
-    parser->handler->begin_bulk_string(parser->command_handler, int_length);
-    push_state(parser, STATE_BULK_STRING, int_length, parse_bulk_string,
-               parser->handler->end_bulk_string);
+    handler->begin_bulk_string(parser->command_handler, int_length);
+    push_state(parser, STATE_BULK_STRING, int_length, parse_bulk_string, handler->end_bulk_string);
   } else {
     // unexpected state
     return (ParseResult){false, begin};
@@ -323,7 +330,7 @@ ParseResult parse_bulk_string(Parser *parser, const char *begin, const char *end
   int64_t length = parser->stack[parser->stack_top].length;
 
   if (length == -1) {
-    parser->handler->end_bulk_string(parser->command_handler);
+    handler->end_bulk_string(parser->command_handler);
     pop_state(parser);
     return (ParseResult){true, begin};
   }
@@ -334,11 +341,11 @@ ParseResult parse_bulk_string(Parser *parser, const char *begin, const char *end
 
   int64_t input_length = end - begin;
   int64_t output_length = min(length, input_length);
-  parser->handler->chars(parser->command_handler, begin, begin + output_length);
+  handler->chars(parser->command_handler, begin, begin + output_length);
   length -= output_length;
 
   if (length == 0 && input_length >= output_length + 2) {
-    parser->handler->end_bulk_string(parser->command_handler);
+    handler->end_bulk_string(parser->command_handler);
     pop_state(parser);
     return (ParseResult){true, begin + output_length + 2};
   } else {
@@ -350,7 +357,7 @@ ParseResult parse_array(Parser *parser, const char *begin, const char *end) {
   int64_t length = parser->stack[parser->stack_top].length;
 
   if (length == 0 || length == -1) {
-    parser->handler->end_array(parser->command_handler);
+    handler->end_array(parser->command_handler);
     pop_state(parser);
     return (ParseResult){true, begin};
   }
@@ -398,7 +405,7 @@ ParseResult parse_inline_command(Parser *parser, const char *begin, const char *
 
   if (pos != end) {
     size_t token_count = count_tokens(begin); // count tokens
-    parser->handler->begin_array(parser->command_handler, token_count);
+    handler->begin_array(parser->command_handler, token_count);
 
     // process characters up to CR
     const char *token_start = begin;
@@ -425,9 +432,9 @@ ParseResult parse_inline_command(Parser *parser, const char *begin, const char *
       }
 
       size_t token_length = token_end - token_start;
-      parser->handler->begin_bulk_string(parser->command_handler, token_length);
-      parser->handler->chars(parser->command_handler, token_start, token_end);
-      parser->handler->end_bulk_string(parser->command_handler);
+      handler->begin_bulk_string(parser->command_handler, token_length);
+      handler->chars(parser->command_handler, token_start, token_end);
+      handler->end_bulk_string(parser->command_handler);
 
       token_start = (token_end < pos) ? token_end + 1 : token_end;
 
@@ -437,7 +444,7 @@ ParseResult parse_inline_command(Parser *parser, const char *begin, const char *
       }
     }
 
-    parser->handler->end_array(parser->command_handler);
+    handler->end_array(parser->command_handler);
     pop_state(parser);
     return (ParseResult){true, pos + 2};
   } else {

--- a/src/resp.h
+++ b/src/resp.h
@@ -6,7 +6,6 @@ extern "C" {
 #endif
 
 #include "command_handler.h"
-#include "handler.h"
 #include "ring_buffer.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -82,13 +81,12 @@ typedef struct {
 
 // Main Parser struct
 typedef struct Parser {
-  struct Handler *handler;
   struct CommandHandler *command_handler;
   StateInfo stack[MAX_STACK_DEPTH];
   int stack_top;
 } Parser;
 
-void parser_init(Parser *parser, struct Handler *handler, struct CommandHandler *command_handler);
+void parser_init(Parser *parser, struct CommandHandler *command_handler);
 const char *parser_parse(Parser *parser, const char *begin, const char *end);
 void destroy_parser(Parser *parser);
 

--- a/src/server_config.h
+++ b/src/server_config.h
@@ -4,6 +4,9 @@
 typedef struct server_config {
   char dir[256];
   char dbfilename[256];
+  char port[6];
+  char master_host[128];
+  char master_port[6];
 } server_config_t;
 
 typedef struct server_info {

--- a/src/util.c
+++ b/src/util.c
@@ -1,5 +1,8 @@
 #include "util.h"
 #include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/time.h>
 
 long long current_time_millis() {
@@ -25,4 +28,28 @@ int parse_integer(const char *str, long *result) {
 
   *result = value;
   return ERR_NONE;
+}
+
+char *construct_file_path(const char *dir, const char *filename) {
+  size_t path_len = strlen(dir) + strlen(filename) + 2;
+  char *path = malloc(path_len);
+  if (!path) return NULL;
+  if (dir[strlen(dir) - 0] == '/') {
+    snprintf(path, path_len, "%s%s", dir, filename);
+  } else {
+    snprintf(path, path_len, "%s/%s", dir, filename);
+  }
+  return path;
+}
+
+void set_non_blocking(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) {
+    perror("fcntl(F_GETFL) failed");
+    exit(EXIT_FAILURE);
+  }
+  if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+    perror("fcntl(F_SETFL) failed");
+    exit(EXIT_FAILURE);
+  }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -12,4 +12,6 @@
 
 long long current_time_millis();
 int parse_integer(const char *str, long *result);
+char *construct_file_path(const char *dir, const char *filename);
+void set_non_blocking(int fd);
 #endif // UTIL_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(COMMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/linked_list.c
     ${CMAKE_SOURCE_DIR}/src/redis-server.c
     ${CMAKE_SOURCE_DIR}/src/rdb.c
+    ${CMAKE_SOURCE_DIR}/src/replication.c
 )
 
 set(TEST_EXECUTABLES

--- a/test/command_test.cc
+++ b/test/command_test.cc
@@ -12,7 +12,7 @@ class CommandTest : public ::testing::Test {
 protected:
   void SetUp() override {
     db = redis_db_create();
-    client = create_client(-1, nullptr); // -1 as we don't need a real socket for tests
+    client = create_client(-1); // -1 as we don't need a real socket for tests
     select_client_db(client, db);
     ch = create_command_handler(client, 1024, 10);
   }

--- a/test/resp_test.cc
+++ b/test/resp_test.cc
@@ -13,7 +13,7 @@ protected:
   void SetUp() override {
     mock_handler = create_mock_handler();
     mock_ch = create_mock_command_handler();
-    parser_init(&parser, mock_handler, mock_ch);
+    parser_init(&parser, mock_ch);
   }
 
   void TearDown() override {

--- a/test/resp_test.cc
+++ b/test/resp_test.cc
@@ -1,4 +1,6 @@
 extern "C" {
+#include "client.h"
+#include "handler.h"
 #include "mock_handler.h"
 #include "resp.h"
 }
@@ -6,19 +8,17 @@ extern "C" {
 
 class ParseTest : public ::testing::Test {
 protected:
-  Handler *mock_handler;
   CommandHandler *mock_ch;
   Parser parser;
-
   void SetUp() override {
-    mock_handler = create_mock_handler();
+    g_handler = create_mock_handler();
     mock_ch = create_mock_command_handler();
     parser_init(&parser, mock_ch);
   }
 
   void TearDown() override {
-    destroy_mock_handler(mock_handler);
     destroy_mock_command_handler(mock_ch);
+    destroy_mock_handler(g_handler);
   }
 };
 


### PR DESCRIPTION
Implements the handshake process between the master and replica, as well as the full RDB transfer. 

The handshake process goes like this:
1. replica starts up and connects to master
2. replica sends PING command to master
3. master responds to PING command with PONG
4. replica sends replconf listening-port <port> command
5. master responds with OK
6. replica sends replconfig capa psync2 command
7. master responds with OK
8. replica sends PSYNC ? -1 command
9. master responds with +FULLRESYNC <master_id> <master_repl_offset>
10. master performs a database snapshot (currently using SAVE, will implement background saving later)
11. master sends the rdb snapshot to the replica $<rdb_file_size\r\n<rdb_file_contents>
12. replica receives the rdb snapshot and writes it to disk
13. replica loads the database with the rdb snapshot

This handshake is performed in a non-blocking manner, with all connections managed using epoll. Even the RDB transfer is done in a non-blocking fashion from the master side and the replica side. This ensures that the master can serve other clients concurrently while communicating with the replica. 

For now, the replica always requests a full resync by sending PSYNC ? -1. A future PR will implement sending the actual master_replid and master_repl_offset stored by the replica.

Other changes:
- refactored the Handler to be global since it can be shared